### PR TITLE
updated images  with img src={{ news-image }}

### DIFF
--- a/components/02-components/02-content-group/02-news-group/news-group.hbs
+++ b/components/02-components/02-content-group/02-news-group/news-group.hbs
@@ -1,98 +1,163 @@
-<div class="news-card" style="margin-bottom: 150px;">
-    <h6 class="h6 fw-bold">Blue Example</h6>
-    <div class="inner-sec-headings">
+<h6 class="h6 fw-bold">
+    Blue Example
+</h6>
+<hr />
+<!-- Blue Example -->
+<div class="news-card" style="margin-bottom: 150px">
 
-        <h4>UTSA News</h4>
-        <a class="view-all-link" href="#">Read All News Stories <i class="fas fa-arrow-right"></i></a>
+    <div class="inner-sec-headings">
+        <h4>
+            UTSA News
+        </h4>
+        <a class="view-all-link" href="#">
+            Read All News Stories
+            <i class="fas fa-arrow-right"></i>
+        </a>
     </div>
-    <div class="row">a
+    <div class="row">
         <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
             <div class="news-card-componet-div blue">
                 <div class="news-card-img">
-                    <img src="{{ news-image }}" alt="Card Image">
+                    <img src={{ news-image }} alt="Card Image" />
                 </div>
                 <div class="news-card-cntnt">
-                    <p class="news-date">June 1, 2021</p>
-                    <a class="news-card-link" href="#">Lorem ipsum dolor sit amet, conse ctetur adip elit.</a>
-                    <p class="published-status">Published By Lorem Ipsum</p>
-                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                    <p class="news-date">
+                        June 1, 2021
+                    </p>
+                    <a class="news-card-link" href="#">
+                        Lorem ipsum dolor sit amet, conse ctetur adip elit.
+                    </a>
+                    <p class="published-status">
+                        Published By Lorem Ipsum
+                    </p>
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    </p>
                 </div>
             </div>
         </div>
         <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
             <div class="news-card-componet-div blue">
                 <div class="news-card-img">
-                    <img src="{{ news-image-01 }}" alt="Card Image">
+                    <img src={{ news-image-01 }} alt="Card Image" />
                 </div>
                 <div class="news-card-cntnt">
-                    <p class="news-date">June 1, 2021</p>
-                    <a class="news-card-link" href="#">Lorem ipsum dolor sit amet, conse ctetur adip elit.</a>
-                    <p class="published-status">Published By Lorem Ipsum</p>
-                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                    <p class="news-date">
+                        June 1, 2021
+                    </p>
+                    <a class="news-card-link" href="#">
+                        Lorem ipsum dolor sit amet, conse ctetur adip elit.
+                    </a>
+                    <p class="published-status">
+                        Published By Lorem Ipsum
+                    </p>
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    </p>
                 </div>
             </div>
         </div>
         <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
             <div class="news-card-componet-div blue">
                 <div class="news-card-img">
-                    <img src="{{ news-image-02 }}" alt="Card Image">
+                    <img src={{ news-image-02 }} alt="Card Image" />
                 </div>
                 <div class="news-card-cntnt">
-                    <p class="news-date">June 1, 2021</p>
-                    <a class="news-card-link" href="#">Lorem ipsum dolor sit amet, conse ctetur adip elit.</a>
-                    <p class="published-status">Published By Lorem Ipsum</p>
-                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                    <p class="news-date">
+                        June 1, 2021
+                    </p>
+                    <a class="news-card-link" href="#">
+                        Lorem ipsum dolor sit amet, conse ctetur adip elit.
+                    </a>
+                    <p class="published-status">
+                        Published By Lorem Ipsum
+                    </p>
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    </p>
                 </div>
             </div>
         </div>
     </div>
 </div>
-
+<h6 class="h6 fw-bold">
+    Gray Example
+</h6>
+<hr />
+<!-- Gray Example -->
 <div class="news3-card-laout-grey position-relative">
     <div class="news-card">
-        <h6 class="h6 fw-bold">Gray Example</h6>
-        <div class="inner-sec-headings">
 
-            <h4>UTSA News</h4>
-            <a class="view-all-link" href="#">Read All News Stories <i class="fas fa-arrow-right"></i></a>
+        <div class="inner-sec-headings">
+            <h4>
+                UTSA News
+            </h4>
+            <a class="view-all-link" href="#">
+                Read All News Stories
+                <i class="fas fa-arrow-right"></i>
+            </a>
         </div>
         <div class="row">
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
                 <div class="news-card-componet-div white">
                     <div class="news-card-img">
-                        <img src="{{ news-image }}" alt="Card Image">
+                        <img src={{ news-image }} alt="Card Image" />
                     </div>
                     <div class="news-card-cntnt">
-                        <p class="news-date">June 1, 2021</p>
-                        <a class="news-card-link" href="#">Lorem ipsum dolor sit amet, conse ctetur adip elit.</a>
-                        <p class="published-status">Published By Lorem Ipsum</p>
-                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                        <p class="news-date">
+                            June 1, 2021
+                        </p>
+                        <a class="news-card-link" href="#">
+                            Lorem ipsum dolor sit amet, conse ctetur adip elit.
+                        </a>
+                        <p class="published-status">
+                            Published By Lorem Ipsum
+                        </p>
+                        <p>
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        </p>
                     </div>
                 </div>
             </div>
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
                 <div class="news-card-componet-div white">
                     <div class="news-card-img">
-                        <img src="{{ news-image-01 }}" alt="Card Image">
+                        <img src={{ news-image-01 }} alt="Card Image" />
                     </div>
                     <div class="news-card-cntnt">
-                        <p class="news-date">June 1, 2021</p>
-                        <a class="news-card-link" href="#">Lorem ipsum dolor sit amet, conse ctetur adip elit.</a>
-                        <p class="published-status">Published By Lorem Ipsum</p>
-                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                        <p class="news-date">
+                            June 1, 2021
+                        </p>
+                        <a class="news-card-link" href="#">
+                            Lorem ipsum dolor sit amet, conse ctetur adip elit.
+                        </a>
+                        <p class="published-status">
+                            Published By Lorem Ipsum
+                        </p>
+                        <p>
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        </p>
                     </div>
                 </div>
             </div>
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
                 <div class="news-card-componet-div white">
                     <div class="news-card-img">
-                        <img src="{{ news-image-02 }}" alt="Card Image">
+                        <img src={{ news-image-02 }} alt="Card Image" />
                     </div>
                     <div class="news-card-cntnt">
-                        <p class="news-date">June 1, 2021</p>
-                        <a class="news-card-link" href="#">Lorem ipsum dolor sit amet, conse ctetur adip elit.</a>
-                        <p class="published-status">Published By Lorem Ipsum</p>
-                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                        <p class="news-date">
+                            June 1, 2021
+                        </p>
+                        <a class="news-card-link" href="#">
+                            Lorem ipsum dolor sit amet, conse ctetur adip elit.
+                        </a>
+                        <p class="published-status">
+                            Published By Lorem Ipsum
+                        </p>
+                        <p>
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        </p>
                     </div>
                 </div>
             </div>

--- a/components/02-components/02-content-group/02-news-group/news-group.hbs
+++ b/components/02-components/02-content-group/02-news-group/news-group.hbs
@@ -18,7 +18,7 @@
         <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
             <div class="news-card-componet-div blue">
                 <div class="news-card-img">
-                    <img src={{ news-image }} alt="Card Image" />
+                    <img src="{{path '/college-dls/college/images/News_Blog.png'}}" alt="Card Image" />
                 </div>
                 <div class="news-card-cntnt">
                     <p class="news-date">
@@ -39,7 +39,7 @@
         <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
             <div class="news-card-componet-div blue">
                 <div class="news-card-img">
-                    <img src={{ news-image-01 }} alt="Card Image" />
+                    <img src="{{path '/college-dls/college/images/News_Blog-1.png'}}" alt="Card Image" />
                 </div>
                 <div class="news-card-cntnt">
                     <p class="news-date">
@@ -60,7 +60,7 @@
         <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
             <div class="news-card-componet-div blue">
                 <div class="news-card-img">
-                    <img src={{ news-image-02 }} alt="Card Image" />
+                    <img src="{{path '/college-dls/college/images/News_Blog-2.png'}}" alt="Card Image" />
                 </div>
                 <div class="news-card-cntnt">
                     <p class="news-date">
@@ -101,7 +101,7 @@
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
                 <div class="news-card-componet-div white">
                     <div class="news-card-img">
-                        <img src={{ news-image }} alt="Card Image" />
+                        <img src="{{path '/college-dls/college/images/News_Blog.png'}}" alt="Card Image" />
                     </div>
                     <div class="news-card-cntnt">
                         <p class="news-date">
@@ -122,7 +122,7 @@
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
                 <div class="news-card-componet-div white">
                     <div class="news-card-img">
-                        <img src={{ news-image-01 }} alt="Card Image" />
+                        <img src="{{path '/college-dls/college/images/News_Blog-1.png'}}" alt="Card Image" />
                     </div>
                     <div class="news-card-cntnt">
                         <p class="news-date">
@@ -143,7 +143,7 @@
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
                 <div class="news-card-componet-div white">
                     <div class="news-card-img">
-                        <img src={{ news-image-02 }} alt="Card Image" />
+                        <img src="{{path '/college-dls/college/images/News_Blog-2.png'}}" alt="Card Image" />
                     </div>
                     <div class="news-card-cntnt">
                         <p class="news-date">

--- a/components/02-components/02-content-group/02-news-group/news-group.scss
+++ b/components/02-components/02-content-group/02-news-group/news-group.scss
@@ -1,18 +1,17 @@
 /* components/02-components/02-content-group/02-news-group/news-group.scss */
 /* BEGIN news-group.scss */
 
-@media (min-width: 992px) {
-    .news3-card-laout-grey::after {
-        content: '';
-        position: absolute;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        width: 100%;
-        height: 69%;
-        background-color: #e7e7e7;
-        z-index: -1;
-    }
+
+.news3-card-laout-grey::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: 69%;
+    background-color: #e7e7e7;
+    z-index: -1;
 }
 
 /* END news-group.scss */


### PR DESCRIPTION
If the quotes are left off, it seems to work.

Example - 
prevous version: `img src="{{ news-image }}"`
this version: `img src={{ news-image }}`

Also, on  news-group.scss. I removed the media query for the selector used in the Gray Example, because the gray background needs to show on all breakpoints. The white clipped corner isn't visible without it.