### PR TITLE
Accordion Active State - text color

### DIFF
--- a/components/03-sections/01-accordion/accordion.scss
+++ b/components/03-sections/01-accordion/accordion.scss
@@ -38,6 +38,21 @@
 #accordion .card {
 	border: none;
 }
+#accordion .card-header > .card-link {
+    display: block;
+    padding: 20px 31px;
+    font-size: 21px;
+    background-color: $blue;
+    color: $white;
+    position: relative;
+    font-weight: 600;
+    margin-bottom: 0px;
+}
+#accordion .active .card-link {
+    color: $white;
+    background-color: $grey;
+    border-top: 6px solid $orange-a11y;
+}
 #accordion .card-header>.card-link::after {
 	position: absolute;
 	right: 31px;


### PR DESCRIPTION
Updated css styles to replace color hex with SASS names. This fixed …the text on active state of accordion.

See screenshot of new active state
<img width="559" alt="Screen Shot 2022-05-25 at 11 10 37 AM" src="https://user-images.githubusercontent.com/92815346/170308437-397922b9-7448-452f-ad65-c4a3c25189f2.png">
.