### PR TITLE
Fixed label and tab background color

### DIFF
--- a/components/02-components/02-tab/tab.hbs
+++ b/components/02-components/02-tab/tab.hbs
@@ -14,7 +14,7 @@
          {{#each tabs}}
          <div id="{{id}}" class="tab-pane fade in {{#if @first}}active{{/if}} show">
              <div class="card-body">
-                 <div class="tab-body-cntnt">
+                 <div class="tab-body-content">
                      <h5>{{heading}}</h5>
                      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tincidunt urna a porta
                          lobortis. Aliquam sit amet eros quam. Fusce venenatis ipsum non est porta porttitor. Curabitur

--- a/components/02-components/02-tab/tab.scss
+++ b/components/02-components/02-tab/tab.scss
@@ -23,8 +23,9 @@
 	font-size: 16px;
 	color: $blue;
 	font-weight: 600;
+	text-decoration: none;
 }
-.tab-wrapper .tab-content .tab-body-cntnt h5 {
+.tab-wrapper .tab-content .tab-body-content h5 {
 	font-size: 28px;
 	color: $orange-a11y;
 	font-weight: 400;
@@ -42,6 +43,7 @@
 .tab-header .nav-tabs>li {
 	margin-right: 5px;
 	width: 33.3%;
+	background-color: $white-b;
 }
 .tab-header .nav-tabs>li:last-child {
 	margin-right: 0px;
@@ -50,13 +52,13 @@
 	padding-top: 88px;
 	padding-bottom: 88px;
 }
-.tab-wrapper .tab-content .tab-body-cntnt {
+.tab-wrapper .tab-content .tab-body-content {
 	padding-left: 85px;
 	max-width: 648px;
 	width: 100%;
 	font-size: 28px;
 }
-.tab-wrapper .tab-content .tab-body-cntnt .h5 {
+.tab-wrapper .tab-content .tab-body-content .h5 {
 	color: $orange-a11y;
 	font-weight: 400;
 }
@@ -66,7 +68,7 @@
 	margin-bottom: 30px;
 	font-size: 17px;
 }
-.tab-wrapper .tab-content .tab-body-cntnt ul {
+.tab-wrapper .tab-content .tab-body-content ul {
 	padding-left: 18px;
 }
 .ul-list li {


### PR DESCRIPTION
Removed anchor underline on tab label. Adjusted the tab <li> background color to prevent white from showing on inactive tabs when active tab label is more than one line.

<img width="1186" alt="Screen Shot 2022-05-25 at 12 37 14 PM" src="https://user-images.githubusercontent.com/92815346/170329401-4692c6d0-7e3a-4db2-988c-4accb4b3f71f.png">
<img width="1339" alt="Screen Shot 2022-05-25 at 12 38 20 PM" src="https://user-images.githubusercontent.com/92815346/170329404-fabbf8c8-e687-40d4-83cd-87c24de09e5e.png">

