### PR TITLE
Minor CSS fixes, Added arrow icon back for now

### DIFF
--- a/components/01-visual-styling/03-button/03-angled-button/angled-button--blue.hbs
+++ b/components/01-visual-styling/03-button/03-angled-button/angled-button--blue.hbs
@@ -1,3 +1,4 @@
-<div class="blue-action-btn btn-icon">
-    <a href="#" class="action-btn">Call to Action</a>
+<div class="blue-action-btn">
+    <a href="#" class="action-btn">Call to Action <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
 </div>

--- a/components/01-visual-styling/03-button/03-angled-button/angled-button--large.hbs
+++ b/components/01-visual-styling/03-button/03-angled-button/angled-button--large.hbs
@@ -1,13 +1,16 @@
 <div class="roadrunner-btns">
     <div class="row">
-        <div class="orange-action-large-btn btn-icon-large col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
-            <a href="#" class="action-btn btn-large">Request Information</a>
+        <div class="orange-action-large-btn col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
+            <a href="#" class="action-btn btn-large">Request Information <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
         </div>
-        <div class="orange-action-large-btn btn-icon-large col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
-            <a href="#" class="action-btn btn-large">Visit Campus</a>
+        <div class="orange-action-large-btn col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
+            <a href="#" class="action-btn btn-large">Visit Campus <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
         </div>
-        <div class="orange-action-large-btn btn-icon-large col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
-            <a href="#" class="action-btn btn-large">Apply Now</a>
+        <div class="orange-action-large-btn col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
+            <a href="#" class="action-btn btn-large">Apply Now <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
         </div>
     </div>
 </div>
@@ -16,14 +19,17 @@
 
 <div class="roadrunner-btns">
     <div class="row">
-        <div class="blue-action-large-btn btn-icon-large col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
-            <a href="#" class="action-btn btn-large">Request Information</a>
+        <div class="blue-action-large-btn col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
+            <a href="#" class="action-btn btn-large">Request Information <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
         </div>
-        <div class="blue-action-large-btn btn-icon-large col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
-            <a href="#" class="action-btn btn-large">Visit Campus</a>
+        <div class="blue-action-large-btn col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
+            <a href="#" class="action-btn btn-large">Visit Campus <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
         </div>
-        <div class="blue-action-large-btn btn-icon-large col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
-            <a href="#" class="action-btn btn-large">Apply Now</a>
+        <div class="blue-action-large-btn col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
+            <a href="#" class="action-btn btn-large">Apply Now <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
         </div>
     </div>
 </div>

--- a/components/01-visual-styling/03-button/03-angled-button/angled-button.hbs
+++ b/components/01-visual-styling/03-button/03-angled-button/angled-button.hbs
@@ -1,3 +1,4 @@
-<div class="orange-action-btn btn-icon">
-    <a href="#" class="action-btn">Call to Action</a>
+<div class="orange-action-btn">
+    <a href="#" class="action-btn">Call to Action <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
 </div>

--- a/components/01-visual-styling/03-button/03-angled-button/angled-button.scss
+++ b/components/01-visual-styling/03-button/03-angled-button/angled-button.scss
@@ -10,6 +10,7 @@
 	padding-top: 22px;
 	padding-bottom: 22px;
 	text-decoration: none;
+	margin-bottom: 5px;
 }
 
 .action-btn.btn-large::after {
@@ -60,32 +61,6 @@
 	font-size: 16px;
 	color: $blue;
 	font-weight: 700;
-}
-
-.btn-icon::after {
-	font-family: "Font Awesome 5 Pro";
-    font-weight: 500;
-    font-size: 15px;
-    content: "\f061";
-    display: flex;
-    position: relative;
-    color: #fff;
-    right: 12px;
-    float: right;
-    top: -34px;
-}
-
-.btn-icon-large::after {
-	font-family: "Font Awesome 5 Pro";
-    font-weight: 500;
-    font-size: 15px;
-    content: "\f061";
-    display: flex;
-    position: relative;
-    color: #fff;
-    right: 12px;
-    float: right;
-    top: -44px;
 }
 
 /* END angled-button.scss */

--- a/components/02-components/03-card/01-action-card/action-card.hbs
+++ b/components/02-components/03-card/01-action-card/action-card.hbs
@@ -1,8 +1,8 @@
 <!--Card Component -->
-<div class="content-card " id="content-card">
+<div class="content-card" id="content-card">
     <div class="content-card-list">
         <div class="flex-row flex-wrap">
-        <div class="card-flex-box ">
+        <div class="card-flex-box">
             <div class="content-card position-relative white-bg">
             <div class="content-card-img">
                 <img src="{{ path image }}" alt="Content Card Image">

--- a/components/02-components/03-card/01-action-card/action-card.scss
+++ b/components/02-components/03-card/01-action-card/action-card.scss
@@ -38,6 +38,7 @@
 .content-card-content {
 	padding: 26px 33px 87px 33px;
 	position: relative;
+
 }
 
 .content-card-content .content-card-link {
@@ -72,19 +73,14 @@
 	bottom: 25px;
 	left: 0;
 	right: 0;
-	margin: 0px 33px;
+	margin: 0px;
 	background-color: $blue;
 	color: $white;
-	max-width: 95%;
 }
 
 .content-card .action-btn:hover {
 	background-color: $orange-b;
 	color: $white;
-}
-
-.content-card-content>.btn-icon::after {
-    top:27px;
 }
 
 .column-2-content-card {
@@ -145,11 +141,8 @@
 	}
 	.content-card .action-btn {
 		position: relative;
-		margin: 45px 2% 0px 2%;
+		margin-top: 40px;
 	}
-	.content-card-content>.btn-icon::after {
-		right:31px;
-		top:-59px;
-	}
+
 }
 /* END action-card.scss */

--- a/components/02-components/04-profile/01-profile-card/profile-card.hbs
+++ b/components/02-components/04-profile/01-profile-card/profile-card.hbs
@@ -7,6 +7,6 @@
         <p class="profile-card-title">{{ title }}</p>
         <a class="phone-no" href="tel:{{ phone }}">{{ phone }}</a> 
         <a class="mail-info" href="mailto:{{ email }}">{{ email }}</a>
-        <p>{{ content }}</p>
+        <p class="profile-description">{{ content }}</p>
     </div>
 </div>

--- a/components/02-components/04-profile/01-profile-card/profile-card.scss
+++ b/components/02-components/04-profile/01-profile-card/profile-card.scss
@@ -42,10 +42,11 @@
 
 		.profile-card-title {
 			margin-bottom: 0px;
+			font-size:15px;
 		}
 
-		.profile-card-title {
-			font-size: 15px;
+		.profile-description {
+			padding: 10px 0;
 		}
 	}
 

--- a/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--2up.hbs
+++ b/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--2up.hbs
@@ -13,8 +13,9 @@
             </div>
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
                 {{#each actions}}
-                <div class="blue-action-btn btn-icon">
-                    <a href="{{ url }}" class="action-btn"> {{ text }} </a>
+                <div class="blue-action-btn">
+                    <a href="{{ url }}" class="action-btn"> {{ text }} <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
                 </div>
                 {{/each}}
             </div>

--- a/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--blue-2up.hbs
+++ b/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--blue-2up.hbs
@@ -13,8 +13,9 @@
             </div>
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
                 {{#each actions}}
-                <div class="orange-action-btn btn-icon">
-                    <a href="{{ url }}" class="action-btn"> {{ text }}</a>
+                <div class="orange-action-btn">
+                    <a href="{{ url }}" class="action-btn"> {{ text }} <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
                 </div>
                 {{/each}}
             </div>

--- a/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--blue.hbs
+++ b/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--blue.hbs
@@ -14,8 +14,9 @@
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
                 {{#each actions}}
                 {{#if @first}}
-                <div class="orange-action-btn btn-icon">
-                    <a href="{{ url }}" class="action-btn"> {{ text }} </a>
+                <div class="orange-action-btn">
+                    <a href="{{ url }}" class="action-btn"> {{ text }} <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
                 </div>
                 {{/if}}
                 {{/each}}

--- a/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--colors.hbs
+++ b/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--colors.hbs
@@ -13,8 +13,9 @@
             </div>
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
                 {{#each actions}}
-                <div class="orange-action-btn btn-icon">
-                    <a href="{{ url }}" class="action-btn"> {{ text }}</a>
+                <div class="orange-action-btn">
+                    <a href="{{ url }}" class="action-btn"> {{ text }} <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
                 </div>
                 {{/each}}
             </div>

--- a/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--grey.hbs
+++ b/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--grey.hbs
@@ -14,8 +14,9 @@
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
                 {{#each actions}}
                 {{#if @first}}
-                <div class="blue-action-btn btn-icon">
-                    <a href="{{ url }}" class="action-btn"> {{ text }}</a>
+                <div class="blue-action-btn">
+                    <a href="{{ url }}" class="action-btn"> {{ text }} <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
                 </div>
                 {{/if}}
                 {{/each}}

--- a/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--orange-2up.hbs
+++ b/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--orange-2up.hbs
@@ -13,8 +13,9 @@
             </div>
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
                 {{#each actions}}
-                <div class="blue-action-btn btn-icon">
-                    <a href="{{ url }}" class="action-btn"> {{ text }}</a>
+                <div class="blue-action-btn">
+                    <a href="{{ url }}" class="action-btn"> {{ text }} <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
                 </div>
                 {{/each}}
             </div>

--- a/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--orange.hbs
+++ b/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons--orange.hbs
@@ -14,8 +14,9 @@
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
                 {{#each actions}}
                 {{#if @first}}
-                <div class="blue-action-btn btn-icon">
-                    <a href="{{ url }}" class="action-btn"> {{ text }}</a>
+                <div class="blue-action-btn">
+                    <a href="{{ url }}" class="action-btn"> {{ text }} <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
                 </div>
                 {{/if}}
                 {{/each}}

--- a/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons.hbs
+++ b/components/03-sections/04-call-to-actions/01-call-to-action-buttons/call-to-action-buttons.hbs
@@ -14,8 +14,9 @@
             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
                 {{#each actions}}
                 {{#if @first}}
-                <div class="orange-action-btn btn-icon">
-                    <a href="{{ url }}" class="action-btn"> {{ text }}</a>
+                <div class="orange-action-btn">
+                    <a href="{{ url }}" class="action-btn"> {{ text }} <i class="fas fa-arrow-right"
+                                aria-hidden="true"></i></a>
                 </div>
                 {{/if}}
                 {{/each}}

--- a/components/03-sections/04-call-to-actions/03-enrollment-call-to-action/enrollment-call-to-action--alt.hbs
+++ b/components/03-sections/04-call-to-actions/03-enrollment-call-to-action/enrollment-call-to-action--alt.hbs
@@ -1,6 +1,6 @@
 <section class="enrollment-wrapper " style="background-image: url('{{path '/college-dls/utsa/images/Future-Roadrunner.png'}}');">
     <div class="container">
-        <div class="enrollment-content text-center">
+        <div class="enrollment-cntnt text-center">
             <h2>Interested in Health, <br> Community or Policy?</h2>
             <p>Reach out today to find out more about our programs</p>
             <div class="roadrunner-btns">

--- a/components/03-sections/04-call-to-actions/03-enrollment-call-to-action/enrollment-call-to-action.hbs
+++ b/components/03-sections/04-call-to-actions/03-enrollment-call-to-action/enrollment-call-to-action.hbs
@@ -1,7 +1,7 @@
 <!-- Roadrunner Section -->
  <section class="enrollment-wrapper" style="background-image: url('{{path '/college-dls/utsa/images/Future-Roadrunner.png'}}');">
      <div class="container">
-         <div class="enrollment-content">
+         <div class="enrollment-cntnt">
              <span class="h5">{{ preheading }}</span>
              <h2>{{ headline }}</h2>
              <div class="roadrunner-btns">

--- a/components/03-sections/04-call-to-actions/03-enrollment-call-to-action/enrollment-call-to-action.scss
+++ b/components/03-sections/04-call-to-actions/03-enrollment-call-to-action/enrollment-call-to-action.scss
@@ -38,9 +38,10 @@
 	}
 
 	.enrollment-cntnt h2 {
-		font-size: 7.0rem;
-		line-height: 105px;
+		font-size: 5.5rem;
+		line-height: 110px;
 		font-weight: 500;
+		margin-top: 5px;
 	}
 
 	.roadrunner-btns {


### PR DESCRIPTION
Talked to Lallo, removed btn-icon CSS for now. Was causing some issues in the multiple button/action card components. Could fix but not worth reworking those unless we're sure we want to use the angled buttons in the WYSIWYG editor.

Minor other fixes. Added some padding to profile description. Adjusted font sizes in some callouts.