### PR TITLE
311 tab component inner styling

### DIFF
--- a/components/02-components/02-tab/tab.config.json
+++ b/components/02-components/02-tab/tab.config.json
@@ -6,17 +6,22 @@
 		"tabs": [
 			{
 				"id": "tab-01",
-				"title": "Tab 01",
+				"title": "Student Success Center",
 				"heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 			},
 			{
 				"id": "tab-02",
-				"title": "Tab 02",
+				"title": "Lorem ipsum dolor sit",
 				"heading": "Maecenas tincidunt urna a porta lobortis"
 			},
 			{
 				"id": "tab-03",
-				"title": "Tab 03",
+				"title": "Fusce venenatis ipsum sit",
+				"heading": "Aliquam sit amet eros quam. Fusce venenatis"
+			},
+			{
+				"id": "tab-04",
+				"title": "Lorem ipsum dolor sit",
 				"heading": "Aliquam sit amet eros quam. Fusce venenatis"
 			}
 		]

--- a/components/02-components/02-tab/tab.hbs
+++ b/components/02-components/02-tab/tab.hbs
@@ -15,7 +15,7 @@
          <div id="{{id}}" class="tab-pane fade in {{#if @first}}active{{/if}} show">
              <div class="card-body">
                  <div class="tab-body-content">
-                     <h5>{{heading}}</h5>
+                     <h2>{{heading}} - h2</h2>
                      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tincidunt urna a porta
                          lobortis. Aliquam sit amet eros quam. Fusce venenatis ipsum non est porta porttitor. Curabitur
                          aliquet mattis elit. Mauris eget velit bibendum, auctor risus eu, elementum sem. Fusce magna
@@ -30,6 +30,21 @@
                          <li>Lists can be nested</li>
                          <li>List items can contain other HTML elements</li>
                      </ul>
+                     <h3>{{heading}} - h3</h3>
+                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tincidunt urna a porta
+                         lobortis. Aliquam sit amet eros quam. Fusce venenatis ipsum non est porta porttitor. Curabitur
+                         aliquet mattis elit. Mauris eget velit bibendum, auctor risus eu, elementum sem. Fusce magna
+                         neque, bibendum in efficitur ut, elementum non risus. Aenean vitae elementum risus. Donec ut
+                         sollicitudin nisl. Pellentesque vehicula eu neque ut iaculis. Phasellus dignissim augue in
+                         lorem pharetra dictum. Fusce pellentesque ut ipsum quis malesuada. Duis eu ipsum eget neque
+                         vehicula hendrerit id eu libero.</p>
+                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tincidunt urna a porta
+                         lobortis. Aliquam sit amet eros quam. Fusce venenatis ipsum non est porta porttitor. Curabitur
+                         aliquet mattis elit. Mauris eget velit bibendum, auctor risus eu, elementum sem. Fusce magna
+                         neque, bibendum in efficitur ut, elementum non risus. Aenean vitae elementum risus. Donec ut
+                         sollicitudin nisl. Pellentesque vehicula eu neque ut iaculis. Phasellus dignissim augue in
+                         lorem pharetra dictum. Fusce pellentesque ut ipsum quis malesuada. Duis eu ipsum eget neque
+                         vehicula hendrerit id eu libero.</p>
                  </div>
              </div>
          </div>

--- a/components/02-components/02-tab/tab.scss
+++ b/components/02-components/02-tab/tab.scss
@@ -27,11 +27,6 @@
 		font-weight: 600;
 		text-decoration: none;
 	}
-	.tab-content .tab-body-content h5 {
-		font-size: 28px;
-		color: $orange-a11y;
-		font-weight: 400;
-	}
 	.tab-header .nav-tabs>li>a.active {
 		border-top: 5px solid $orange-b;
 		background-color: $white-b;
@@ -51,47 +46,15 @@
 		margin-right: 0px;
 	}
 	.tab-content {
-		padding-top: 88px;
-		padding-bottom: 88px;
+		padding: 1.5rem;
 	}
 	.tab-content .tab-body-content {
-		padding-left: 85px;
-		max-width: 648px;
 		width: 100%;
-		font-size: 28px;
 	}
 	.tab-content .tab-body-content .h5 {
 		color: $orange-a11y;
 		font-weight: 400;
 	}
-	.tab-component-sec p {
-		line-height: 1.7;
-		margin-top: 30px;
-		margin-bottom: 30px;
-		font-size: 17px;
-	}
-	.tab-content .tab-body-content ul {
-		padding-left: 18px;
-	}
-	
-	li {
-		font-size: 16px;
-		font-weight: normal;
-	}
 
-	p {
-		line-height: 1.5;
-		font-size: 16px;
-		color: $blue;
-	}
-	// .resources-subheading h4 {
-	// 	margin-bottom: 30px;
-	// 	font-size: 32px;
-	// 	color: $blue;
-	// 	font-weight: 700;
-	// }
-	// .resources-list li a:hover {
-	// 	color: $orange-b;
-	// }
 }
 /* END tab.scss */

--- a/components/02-components/02-tab/tab.scss
+++ b/components/02-components/02-tab/tab.scss
@@ -37,24 +37,31 @@
 	.tab-content {
 		background-color: $white-b;
 	}
-	.tab-header .nav-tabs>li {
-		margin-right: 5px;
-		width: 33.3%;
-		background-color: $white-b;
-	}
-	.tab-header .nav-tabs>li:last-child {
-		margin-right: 0px;
-	}
 	.tab-content {
 		padding: 1.5rem;
 	}
 	.tab-content .tab-body-content {
 		width: 100%;
 	}
-	.tab-content .tab-body-content .h5 {
-		color: $orange-a11y;
-		font-weight: 400;
+	.tab-content .tab-body-content {
+		h2, h3, h4, h5 {
+			color: $orange-a11y;
+			font-family: "open sans", sans-serif;
+			font-weight: 400;	
+		}
 	}
 
+	@include media-breakpoint-up(md) {
+		.tab-header .nav-tabs>li {
+			margin-right: 5px;
+		}
+	}
+
+	@include media-breakpoint-down(md) {
+		.tab-header .nav-tabs>li {
+			width: 100%;
+			background-color: $white-b;
+		}
+	}
 }
 /* END tab.scss */

--- a/components/03-sections/01-accordion/accordion.hbs
+++ b/components/03-sections/01-accordion/accordion.hbs
@@ -11,9 +11,7 @@
                 <div id="collapse-01" class="accordion-collapse collapse" data-bs-parent="#accordion">
                     <div class="card-body">
                         <div class="accordion-body-content">
-                            <h5 class="accordion-heading">
-                                {{title}}
-                            </h5>
+                            <h5>{{heading}}</h5>
                             <p>
                                 {{text}}
                             </p>
@@ -52,9 +50,7 @@
                 <div id="collapse-02" class="accordion-collapse collapse" data-bs-parent="#accordion">
                     <div class="card-body">
                         <div class="accordion-body-content">
-                            <h5>
-                                {{title}}
-                            </h5>
+                            <h5>{{title}}</h5>
                             <p>
                                 {{text}}
                             </p>
@@ -93,9 +89,7 @@
                 <div id="collapse-03" class="accordion-collapse collapse" data-bs-parent="#accordion">
                     <div class="card-body">
                         <div class="accordion-body-content">
-                            <h5>
-                                {{title}}
-                            </h5>
+                            <h5>{{title}}</h5>
                             <p>
                                 {{text}}
                             </p>

--- a/components/03-sections/01-accordion/accordion.scss
+++ b/components/03-sections/01-accordion/accordion.scss
@@ -86,29 +86,19 @@
 	position: relative;
 }
 
-.accordion .accordion-body-content {
-	padding-left: 85px;
-	box-sizing: content-box;
-	max-width: 85%;
-	width: 100%;
-}
-
-.accordion .accordion-heading {
-	color: $orange-a11y;
-	font-family: "open sans", sans-serif;
-	font-weight: 400;
-}
-
-
-.accordion .accordion-body-content ul {
-	padding-left: 18px;
+.accordion .card-body {
+	h2, h3, h4, h5 {
+		color: $orange-a11y;
+		font-family: "open sans", sans-serif;
+		font-weight: 400;	
+	}
 }
 
 .accordion .accordion-body-content ul li {
 	font-weight: 400;
 }
 
-@media (max-width: 1199px) {
+@include media-breakpoint-down(xl) {
 	.accordion .accordion-item .card-body {
 		-webkit-box-sizing: border-box;
 		box-sizing: border-box;


### PR DESCRIPTION
- added more tabs and longer tab names for testing
- added more content to the tab to test -content styling
- removed padding and 85% width
- added bootstrap media breakpoints to go 100% tab heading widths on sizes md and down (768px and lower)
- moving hard coded margin-right: 5px on tab heading to only sizes above md which was causing weird tab break issues see #311 
- getting -content classes in sync with .accordion changes
- adding orange color to headings for both components w/o need of a additional class name