### PR TITLE
Text link color fix, Horizontal Event Component fix

### DIFF
--- a/components/01-visual-styling/03-button/01-text-link/text-link.scss
+++ b/components/01-visual-styling/03-button/01-text-link/text-link.scss
@@ -11,6 +11,10 @@
     color: $white;
 }
 
+.blue-bg h2 {
+	color: $white;
+}
+
 .view-all-link i,
 .view-all-link svg {
 	color: $orange-a11y;

--- a/components/02-components/03-card/02-event-card/event-card.scss
+++ b/components/02-components/03-card/02-event-card/event-card.scss
@@ -109,7 +109,6 @@
 	color: $blue;
 }
 
-
 .deadline4-cards-blue {
 	margin-bottom: 100px;
 }
@@ -119,7 +118,11 @@
 }
 
 .events-listing-content .h5:hover {
-	color: #0c2340;
+	color: $blue;
+}
+
+.events-listing-content a:hover {
+	background:#dbdee350;
 }
 
 @media (max-width: 991px) {


### PR DESCRIPTION
Fixed issue with H2's in text link components being blue over a blue background.

Bigger issue: It seems that horizontal event (individual and listing) component is structured in a way that the whole component links to the event page/info. This causes it to inherit the <a> hover styles, which means it currently turns completely grey on hover. I added some component specific CSS to have the grey be trasparent on hover for now, but we could talk about if there's a better way to handle this.