### PR TITLE
348: accordion - updated color scheme: 

### DIFF
--- a/components/03-sections/01-accordion/accordion.scss
+++ b/components/03-sections/01-accordion/accordion.scss
@@ -29,8 +29,8 @@
 	}
 
 	.accordion-item .accordion-button {
-		background-color: $blue;
-		color: $white;
+		background-color: $white-b;
+		color: $blue;
 		display: block;
 		font-size: 21px;
 		font-weight: 600;
@@ -40,17 +40,16 @@
 	}
 
 	.accordion-button:not(.collapsed) {
-		color: $blue;
-		background-color: $grey;
+		color: $white;
+		background-color: $blue;
 		border-top: 6px solid $orange-a11y;
 		margin-top: -2px;
 	}
 
 	.accordion-button:not(.collapsed)::after {
 		align-items: center;
-		background-color: $blue;
+		color: $orange-a11y;
 		bottom: 0;
-		color: $white;
 		display: flex;
 		height: 100%;
 		transform: rotate(0deg);
@@ -75,10 +74,14 @@
 		position: absolute;
 		right: 31px;
 		top: 15px;
+		color: $orange-a11y;
+		// by default from Bootstrap expand/collapse scss, this selector pulls in a background image icon "v" so, removing it here
+		background-image: none;
 	}
 
 	.accordion-button:not(.collapsed):after {
 		content: "×";
+		color: $white;
 	}
 
 	.accordion-body-content {
@@ -88,6 +91,7 @@
 	.card-body {
 		background-color: #f6f6f6;
 		position: relative;
+		border-bottom: 6px solid $blue;
 	}
 
 	.accordion-body-content ul li {

--- a/components/03-sections/01-accordion/accordion.scss
+++ b/components/03-sections/01-accordion/accordion.scss
@@ -28,6 +28,7 @@
 		margin-bottom: 0;
 	}
 
+	// heading - collapsed state
 	.accordion-item .accordion-button {
 		background-color: $white-b;
 		color: $blue;
@@ -39,26 +40,7 @@
 		position: relative;
 	}
 
-	.accordion-button:not(.collapsed) {
-		color: $white;
-		background-color: $blue;
-		border-top: 6px solid $orange-a11y;
-		margin-top: -2px;
-	}
-
-	.accordion-button:not(.collapsed)::after {
-		align-items: center;
-		color: $orange-a11y;
-		bottom: 0;
-		display: flex;
-		height: 100%;
-		transform: rotate(0deg);
-		justify-content: center;
-		right: 0;
-		top: 0;
-		width: 77px;
-	}
-
+	// + toggle icon
 	.accordion-button:after {
 		background-repeat: no-repeat;
 		background-size: 1.25rem;
@@ -79,10 +61,38 @@
 		background-image: none;
 	}
 
+	// END + toggle icon
+	// END heading - collapsed state
+
+	// heading - expanded state
+	.accordion-button:not(.collapsed) {
+		color: $white;
+		background-color: $blue;
+		border-top: 6px solid $orange-a11y;
+		margin-top: -2px;
+	}
+
+	// X toggle icon
+	.accordion-button:not(.collapsed)::after {
+		align-items: center;
+		color: $orange-a11y;
+		bottom: 0;
+		display: flex;
+		height: 100%;
+		transform: rotate(0deg);
+		justify-content: center;
+		right: 0;
+		top: 0;
+		width: 77px;
+	}
+
 	.accordion-button:not(.collapsed):after {
 		content: "×";
 		color: $white;
 	}
+
+	// END X toggle icon
+	// END heading - expanded state
 
 	.accordion-body-content {
 		padding: 1.5rem;


### PR DESCRIPTION
Requested in Issue: https://github.com/utsa-asc/college-dls/issues/348

Reversed styles of accordion heading to make collapsed state light and expanded state dark.

Screenshot of changes in appearance:
<img width="1036" alt="Screen Shot 2022-06-28 at 10 38 49 AM" src="https://user-images.githubusercontent.com/92815346/176221700-4cf44e2a-6de6-4db3-9c29-68639612fe12.png">

![respondaccordionly](https://user-images.githubusercontent.com/92815346/176227809-33b5b407-34e8-4fe2-be23-43bbdef7f03f.jpg)

