### PR TITLE
Headline sizing updates, Separating H classes

### DIFF
--- a/components/01-visual-styling/02-typography/01-headline/headline.scss
+++ b/components/01-visual-styling/02-typography/01-headline/headline.scss
@@ -1,43 +1,73 @@
 /* components/01-visual-styling/03-typography/01-headline/headline.scss */
 /* BEGIN headline.scss */
-h1, .h1 {
-	font-size: 50px;
+h1 {
+	font-size: 3rem;
 	color: $blue;
 	font-weight: 700;
 }
 
-h2, .h2 {
-	font-size: 42px;
+.h1 {
+	font-size: 3rem;
+	font-weight: 700;
+}
+
+h2 {
+	font-size: 2.5rem;
 	color: $blue;
 	font-weight: 700;
 }
 
-h3, .h3 {
-	font-size: 38px;
+.h2 {
+	font-size: 2.5rem;
+	font-weight: 700;
+}
+
+h3 {
+	font-size: 2.25rem;
 	color: $blue;
 	font-weight: 700;
 }
 
-h4, .h4 {
-	font-size: 32px;
+.h3 {
+	font-size: 2.25rem;
+	font-weight: 700;
+}
+
+h4 {
+	font-size: 2rem;
 	color: $blue;
 	font-weight: 700;
 }
 
-h5, .h5 {
-	font-size: 28px;
+.h4 {
+	font-size: 2rem;
+	font-weight: 700;
+}
+
+h5 {
+	font-size: 1.75rem;
 	color: $blue;
 	font-weight: 700;
 }
 
-h6, .h6 {
-	font-size: 21px;
+.h5 {
+	font-size: 1.75rem;
+	font-weight: 700;
+}
+
+h6 {
+	font-size: 1.5rem;
 	color: $blue;
+	font-weight: 700;
+}
+
+.h6 {
+	font-size: 1.5rem;
 	font-weight: 700;
 }
 
 .display-1 {
-	font-size: 6.6rem;
+	font-size: 6.5rem;
 	line-height: 0.8;
 	font-weight: 600;
 	font-family: "kulturista-web", serif;

--- a/components/01-visual-styling/02-typography/04-intro/intro.hbs
+++ b/components/01-visual-styling/02-typography/04-intro/intro.hbs
@@ -1,10 +1,8 @@
-<div class="intro-text" id="intro">
-    <div class="container">
-        <div class="d-flex flex-row">
-            <div class="w-100">
-                <h5 class="h5">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tincidunt urna a porta
-                    lobortis. Aliquam sit amet eros quam. Fusce venenatis ipsum non est porta porttitor.</h5>
+<div class="container">
+        <div class="row">
+            <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12">
+                <p class="intro">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tincidunt urna a porta
+                lobortis. Aliquam sit amet eros quam. Fusce venenatis ipsum non est porta porttitor.</p>
             </div>
         </div>
-    </div>
 </div>

--- a/components/01-visual-styling/02-typography/04-intro/intro.scss
+++ b/components/01-visual-styling/02-typography/04-intro/intro.scss
@@ -1,10 +1,10 @@
 /* components/01-visual-styling/02-typography/04-intro/intro.scss */
 /* BEGIN intro.scss */
 
-#intro .d-flex {
-	border-top: 2px solid $orange-a11y;
-	padding-top: 53px;
-	padding-bottom: 53px;
+.intro {
+	font-size: 1.5rem;
+	line-height: 1.5;
+	font-weight: 600;
 }
 
 


### PR DESCRIPTION
OK, hoping to address a couple of things here.

I updated the sizes of the H tags to rem sizes instead of pixels. The rem sizes are either the same or pretty close to the pixel equivalent, so they should work fine for the actual headers. We might just have to look out for a component here or there that's using an h tag (or an equivalent size) and update it to the rem size if needed.

I also adjusted the CSS to separate the h tags and the .h classes because that wasn't allowing the .orange class to overwrite the blue color on the headers (it's one of the issues on github).

Lastly, I noticed that on the admissions pages that are currently being worked on ( for example, https://futurenew.flywheelsites.com/freshman/admissions/) they are essentially using the h-tags to create a sort of intro paragraph. I know we removed the "Introduction" component because we didn't have a use for it, but I edited it to match what they're trying to do. It's just an .intro class, nothing more involved than that. I think it makes semantic sense to have it instead of trying to add different .h classes to that top text.