### PR TITLE
removing outdated examples

### DIFF
--- a/components/01-visual-styling/04-utility/06-misc/misc.hbs
+++ b/components/01-visual-styling/04-utility/06-misc/misc.hbs
@@ -1,8 +1,3 @@
-<div class="css-box">
-    <p>Right Image Clip : <span class="css-class">.clip-mask-right-bottom</span></p>
-    <p>Left Image Clip : <span class="css-class">.clip-mask-left-bottom</span></p>
-</div>
-
 <section class="py-5 white-bg">
     <div class="container">
         <div class="row">


### PR DESCRIPTION
follow up edit that I left out, now that there are image examples on this page, we no longer need the older css-box block