### PR TITLE
378: Accordion Mobile Issue

### DIFF
--- a/components/03-sections/01-accordion/accordion.scss
+++ b/components/03-sections/01-accordion/accordion.scss
@@ -109,6 +109,26 @@
 	}
 }
 
+@media (max-width: 375px) {
+	.accordion {
+  .accordion-item .accordion-button {
+    padding: 20px 30px 20px 10px;
+	font-size: 19px;
+  }
+
+  .accordion-button:after {
+    right: 8px;
+	font-size: 39px;
+  }
+  // X toggle icon
+  .accordion-button:not(.collapsed)::after {
+    width: 32px;
+	height: 3.5rem;
+  }
+  }
+}
+
+
 @include media-breakpoint-down(xl) {
 	.accordion .accordion-item .card-body {
 		-webkit-box-sizing: border-box;


### PR DESCRIPTION
added custom breakpoint for accordion expand/collapse headers with a lot of content on tiny screens. Everything looks okay with this on screens at both 320px & 375px

<img width="386" alt="Screen Shot 2022-07-14 at 12 14 15 PM" src="https://user-images.githubusercontent.com/92815346/179045499-a1a5a592-fa7e-4ac4-85a9-5c4f2ccaa848.png">

<img width="339" alt="Screen Shot 2022-07-14 at 12 15 13 PM" src="https://user-images.githubusercontent.com/92815346/179045507-a7079e0e-fcb3-44b1-ba8f-25bd4395813e.png">

