### PR TITLE
423 global header search toggle

### DIFF
--- a/components/01-visual-styling/05-branding-standards/01-global-header/global-header.hbs
+++ b/components/01-visual-styling/05-branding-standards/01-global-header/global-header.hbs
@@ -23,7 +23,7 @@
                     <span class="search-icon"><i class="fas fa-search" aria-hidden="true"></i></span> 
                     <span class="search-text">Search</span>
                 </button>
-                <div class="dropdown-menu search-dropdown show" style="position: absolute; inset: 0px auto auto 0px; margin: 0px; transform: translate3d(274px, 122px, 0px);" data-popper-placement="bottom-end">
+                <div class="dropdown-menu " style="position: absolute; inset: 0px auto auto 0px; margin: 0px; transform: translate3d(274px, 122px, 0px);" data-popper-placement="bottom-end">
                     <label for="search" class="d-none">Search</label>
                     <input type="search" placeholder="Search" name="Search" id="q" tabindex="-1" name="q" onblur="if (this.value == '') {this.value = 'Search UTSA';}" onfocus="if (this.value == 'Search UTSA') {this.value = '';}" value="Search UTSA" />
                     <button type="submit" class="search-input-icon" aria-label="Search"><i class="fas fa-search" aria-hidden="true"></i></button>

--- a/components/01-visual-styling/05-branding-standards/01-global-header/global-header.scss
+++ b/components/01-visual-styling/05-branding-standards/01-global-header/global-header.scss
@@ -158,7 +158,7 @@
     }
 }
 
-.search-bar-active #header {
+#header.search-bar-active {
     padding-top: 72px;
 
     .search .dropdown-menu {

--- a/public/js/college-dls.min.js
+++ b/public/js/college-dls.min.js
@@ -1,7 +1,7 @@
 // Navbar Toggle
 $(document).ready(function () {
     $('.search-btn').click(function () {
-        $(this).parents('body').toggleClass('search-bar-active');
+        $(this).parents('#header').toggleClass('search-bar-active');
     });
 
     $('.navbar-toggler').click(function () {

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -1,7 +1,7 @@
 // Navbar Toggle
 $(document).ready(function () {
     $('.search-btn').click(function () {
-        $(this).parents('body').toggleClass('search-bar-active');
+        $(this).parents('#header').toggleClass('search-bar-active');
     });
 
     $('.navbar-toggler').click(function () {


### PR DESCRIPTION
@jampafoo, try this PR out and let me know if this works on future, changes:

- script.js updated to target #header for the toggle instead of body tag
- css changes, padding-top expansion updated to #header.search-bar-active for the change above
- html code, removed everything but the vanilla classes for bootstrap on the dropdown menu:
` <div class="dropdown-menu " ...`