### PR TITLE
Addressed issue #429 with sticky nav on scroll up

### DIFF
--- a/public/js/college-dls.min.js
+++ b/public/js/college-dls.min.js
@@ -67,19 +67,17 @@ $(document).ready(function () {
         $(this).parent().addClass('active');
     })
 
-    $(".Skip-btn").click(function () {
-        $("html").scrollTop(200);
-    });
-
     // Navbar Sticky
-
+    var lastScrollTop = $(window).scrollTop();
     $(window).scroll(function () {
         var scroll = $(window).scrollTop();
-        if (scroll >= 300) {
+        if (scroll < lastScrollTop && scroll!=0) {
             $(".sticky-header").addClass("active", 1000);
         } else {
             $(".sticky-header").removeClass("active", 1000);
         }
+        lastScrollTop = scroll;
+
     });
 
     // Carousel Slide Numbers Js

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -67,19 +67,17 @@ $(document).ready(function () {
         $(this).parent().addClass('active');
     })
 
-    // $(".Skip-btn").click(function () {
-    //     $("html").scrollTop(200);
-    // });
-
-    // Navbar Sti   ky
-
+    // Navbar Sticky
+    var lastScrollTop = $(window).scrollTop();
     $(window).scroll(function () {
         var scroll = $(window).scrollTop();
-        if (scroll >= 300) {
+        if (scroll < lastScrollTop && scroll!=0) {
             $(".sticky-header").addClass("active", 1000);
         } else {
             $(".sticky-header").removeClass("active", 1000);
         }
+        lastScrollTop = scroll;
+
     });
 
     // Carousel Slide Numbers Js


### PR DESCRIPTION
Sticky nav only shows on scroll up. Also, I did notice the blue utility nav only shows at the top of the page. Maybe we could have it displayed as part of the sticky nav. It seems the users might need the search at some point, and having it more accessible would help. 