### PR TITLE
updated styles to prevent image from overflowing 

### DIFF
--- a/components/03-sections/01-accordion/accordion.hbs
+++ b/components/03-sections/01-accordion/accordion.hbs
@@ -13,29 +13,9 @@
                         <div class="accordion-body-content">
                             <h5>{{heading}}</h5>
                             <p>
-                                {{text}}
+                                 <img src="https://utsa-asc.github.io/college-dls/college-dls/college/images/content-highland-card.png">
                             </p>
-                            <ul class="ul-list">
-                                <li class="list-item">Use the HTML <code>&lt;ol&gt;</code> element to define an ordered
-                                    list
-
-                                </li>
-                                <li class="list-item">Use the HTML type attribute to define the numbering type</li>
-                                <li class="list-item">Use the HTML <code>&lt;li&gt;</code> element to define a list item
-                                </li>
-                                <li class="list-item">Lists can be nested
-                                    <ul class="ul-list">
-                                        <li class="list-item">List nested</li>
-                                        <li class="list-item">List nested</li>
-                                    </ul>
-                                </li>
-                                <li class="list-item">List items can contain other HTML elements. This one contains a
-                                    <code>&lt;div&gt;</code> and an <code>&lt;img&gt;</code> HTML element.
-                                    <div>
-                                        <img class="p-2" src="https://utsa-asc.github.io/college-dls/college-dls/college/images/content-highland-card.png">
-                                    </div>
-                                </li>
-                            </ul>
+                            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
                         </div>
                     </div>
                 </div>
@@ -52,29 +32,10 @@
                         <div class="accordion-body-content">
                             <h5>{{title}}</h5>
                             <p>
-                                {{text}}
+                                 <img src="https://utsa-asc.github.io/college-dls/college-dls/college/images/content-highland-card.png">
                             </p>
-                            <ul class="ul-list">
-                                <li class="list-item">Use the HTML <code>&lt;ol&gt;</code> element to define an ordered
-                                    list
-
-                                </li>
-                                <li class="list-item">Use the HTML type attribute to define the numbering type</li>
-                                <li class="list-item">Use the HTML <code>&lt;li&gt;</code> element to define a list item
-                                </li>
-                                <li class="list-item">Lists can be nested
-                                    <ul class="ul-list">
-                                        <li class="list-item">List nested</li>
-                                        <li class="list-item">List nested</li>
-                                    </ul>
-                                </li>
-                                <li class="list-item">List items can contain other HTML elements. This one contains a
-                                    <code>&lt;div&gt;</code> and an <code>&lt;img&gt;</code> HTML element.
-                                    <div>
-                                        <img class="p-2" src="https://utsa-asc.github.io/college-dls/college-dls/college/images/content-highland-card.png">
-                                    </div>
-                                </li>
-                            </ul>
+                            <p>Very little content but image doesn't overflow.</p>
+                        
                         </div>
                     </div>
                 </div>

--- a/components/03-sections/01-accordion/accordion.scss
+++ b/components/03-sections/01-accordion/accordion.scss
@@ -98,8 +98,14 @@
 	// END heading - expanded state
 
 	.accordion-body-content {
+		display: inline-block;
 		padding: 1.5rem;
 	}
+
+	.accordion-body-content img {
+    float: left;
+    padding: 0 15px 15px 0;
+}
 
 	.card-body {
 		background-color: $white-b;


### PR DESCRIPTION
In addition to adding `.accordion-body-content {display: inline-block;} `, I also added padding to the `.acordion-body-content img ` to automatically put some separation between the image and the paragraph content. 

<img width="1252" alt="Screen Shot 2022-08-08 at 4 37 27 PM" src="https://user-images.githubusercontent.com/92815346/183521063-2c4267a9-7150-4cdd-955c-edf1066adf26.png">

