### PR TITLE
added an h2 title for the entire accordion group

### DIFF
--- a/components/03-sections/01-accordion/accordion.config.json
+++ b/components/03-sections/01-accordion/accordion.config.json
@@ -3,6 +3,7 @@
     "name": "accordion",
     "status": "exported",
 	"context": {
+		"group-title": "Accordion Group Title",
 		"heading": "Accordion",
 		"title": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tincidunt urna",
 		"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tincidunt urna a porta lobortis. Aliquam sit amet eros quam. Fusce venenatis ipsum non est porta porttitor. Curabitur aliquet mattis elit. Mauris eget velit bibendum, auctor risus eu, elementum sem. Fusce magna neque, bibendum in efficitur ut, elementum non risus. Aenean vitae elementum risus. Donec ut sollicitudin nisl. Pellentesque vehicula eu neque ut iaculis. Phasellus dignissim augue in lorem pharetra dictum. Fusce pellentesque ut ipsum quis malesuada. Duis eu ipsum eget neque vehicula hendrerit id eu libero."

--- a/components/03-sections/01-accordion/accordion.hbs
+++ b/components/03-sections/01-accordion/accordion.hbs
@@ -1,6 +1,7 @@
 <section class="select-publication-sec scholarship-type-designs">
     <div class="container">
         <div class="accordion" id="accordion">
+            <h2 class="h3 blue mb-4">{{group-title}}</h2>
             <div class="accordion-item">
                 <p class="accordion-header" id="heading-01">
                     <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse"


### PR DESCRIPTION
The h2 point-size was kind of overwhelming so I gave it a .h3 class.

Mobile layout: 
<img width="531" alt="Screen Shot 2022-09-15 at 9 19 54 AM" src="https://user-images.githubusercontent.com/92815346/190428956-db137874-fbf8-4596-ac64-c3814f7cfcdc.png">

Desktop layout: 
<img width="1222" alt="Screen Shot 2022-09-15 at 9 20 24 AM" src="https://user-images.githubusercontent.com/92815346/190429077-eb878ad1-976f-44b7-b4f8-09c604724f89.png">
