### PR TITLE
added h2 title to entire tab group

### DIFF
--- a/components/02-components/02-tab/tab.config.json
+++ b/components/02-components/02-tab/tab.config.json
@@ -3,6 +3,7 @@
     "name": "tab",
     "status": "exported",
 	"context": {
+		"group-title": "Tab Group Title",	
 		"tabs": [
 			{
 				"id": "tab-01",

--- a/components/02-components/02-tab/tab.hbs
+++ b/components/02-components/02-tab/tab.hbs
@@ -1,5 +1,6 @@
  <div class="tab-wrapper">
      <div class="tab-header">
+        <h2 class="h3 blue mb-4">{{group-title}}</h2>
          <ul class="nav nav-tabs">
              {{#each tabs}}
                 {{#if @first}}


### PR DESCRIPTION
Added h2 group title to tabs as well. Styled it the same way as accordion group title.

Mobile: 
<img width="549" alt="Screen Shot 2022-09-15 at 9 42 58 AM" src="https://user-images.githubusercontent.com/92815346/190433984-3ac33924-d2f8-44d5-98fd-64a8e7f73c79.png">

Desktop:
<img width="1173" alt="Screen Shot 2022-09-15 at 9 42 31 AM" src="https://user-images.githubusercontent.com/92815346/190434056-f19f7a6e-9c2c-43cd-bf8c-cf97b5bd1ae5.png">
