### PR TITLE
Bootstrap 5.2 update

### DIFF
--- a/docs/01-index.md
+++ b/docs/01-index.md
@@ -49,8 +49,8 @@ If you need to utilize the DLS on a non *.utsa.edu website, please contact us by
 
 The College DLS was built with [Bootstrap v5](https://getbootstrap.com) and [Fractal](https://fractal.build).  Initial design work and implementation was completed by [Simpson Scarborough](https://www.simpsonscarborough.com).  The following dependencies are also used heavily in the production of this design system:
 
-* [Bootstrap (v5.1.3)](https://getbootstrap.com/docs/5.1/getting-started/introduction/)
-* [Fractal (v1.5.13)](https://fractal.build)
+* [Bootstrap (v5.2.3)](https://getbootstrap.com/docs/5.1/getting-started/introduction/)
+* [Fractal (v1.5.14)](https://fractal.build)
 * [Gulp (v4.0.2)](https://gulpjs.com)
 * [BrowserSync](https://browsersync.io)
 * [SASS (v1.49.9)](https://www.npmjs.com/package/sass)

--- a/fractal.config.js
+++ b/fractal.config.js
@@ -85,7 +85,7 @@ fractal.components.engine(hbs);
  */
 // keep title empty so we can display BG logo
 fractal.set('project.title', 'College Design Language System');
-fractal.set('project.verison', 'v0.1');
+fractal.set('project.verison', 'v0.9.0');
 fractal.set('project.author', 'Academic Strategic Communications <vpaacomms@utsa.edu>');
 // tell Fractal to use the configured theme by default
 fractal.web.theme(ASCTheme);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utsa-college",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "homepage": "https://github.com/utsa-asc/college-dls",
   "license": "ISC",
   "private": true,
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@frctl/fractal": "^1.5.14",
-    "@frctl/handlebars": "^1.2.14",
-    "@frctl/mandelbrot": "^1.10.1",
-    "@popperjs/core": "^2.11.4",
+    "@frctl/handlebars": "^1.2.15",
+    "@frctl/mandelbrot": "^1.10.2",
+    "@popperjs/core": "^2.11.6",
     "bootstrap": "5.2.3",
     "gulp-uglify": "^3.0.2",
     "gulp-useref": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@frctl/handlebars": "^1.2.14",
     "@frctl/mandelbrot": "^1.10.1",
     "@popperjs/core": "^2.11.4",
-    "bootstrap": "5.1.3",
+    "bootstrap": "5.2.3",
     "gulp-uglify": "^3.0.2",
     "gulp-useref": "^5.0.0",
     "jquery": "^3.6.0",

--- a/src/scss/import.scss
+++ b/src/scss/import.scss
@@ -11,6 +11,7 @@
 // Configuration
 @import "../../node_modules/bootstrap/scss/functions";
 @import "../../node_modules/bootstrap/scss/variables";
+@import "../../node_modules/bootstrap/scss/maps";
 @import "../../node_modules/bootstrap/scss/mixins";
 @import "../../node_modules/bootstrap/scss/utilities";
 


### PR DESCRIPTION
big bump to dependencies:

- bootstrap 5.2.3 (latest)
- x.x.1 bumps to various dependencies
- taking this chance to version bump the DLS 0.8.1 -> 0.9

please take a chance to build locally and make sure BS 5.2.3 didn't introduce any major changes, I didn't notice any breaking changes in the change long, but we we are moving from 5.1.x to 5.2.x.