### PR TITLE
removing nested anchors on menu dropdown items

### DIFF
--- a/components/03-sections/02-navigation/03-side-navigation/side-navigation.hbs
+++ b/components/03-sections/02-navigation/03-side-navigation/side-navigation.hbs
@@ -8,7 +8,8 @@
                 <li class="nav-item " >
                     <button class="drop-down-btn plus-toggle" data-bs-toggle="dropdown" aria-label="plus button"
                         aria-expanded="false">
-                    <a href="#"  aria-label="Admission Requirements">Admission Requirements</a>
+
+                        <span id="admissionRequirements" aria-label="admissionRequirements menu dropdown" class="dropdown-label">Admission Requirements</span>
                         <span class="plus-icn"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span class="minus-icn" style="display: none;"><i class="fas fa-minus"
                                 aria-hidden="true"></i></span>

--- a/components/03-sections/02-navigation/03-side-navigation/side-navigation.scss
+++ b/components/03-sections/02-navigation/03-side-navigation/side-navigation.scss
@@ -57,7 +57,7 @@
 			}
 		}
 
-		li.nav-item a {
+		li.nav-item a, li.nav-item button span:first-child {
 			font-size: 1.2rem;
 			border-bottom: 1px $orange-a11y solid;
 		}
@@ -121,7 +121,7 @@
 			padding-right: 15px;
 		}
 
-		li.nav-item button a {
+		li.nav-item button a, li.nav-item button span:first-child {
 			font-size: 17px;
 			color: $blue;
 			font-weight: 400;


### PR DESCRIPTION
first attempt at resolving issue #489.  Will require removal of anchor on menu dropdown in CMS formats:

[College-PROTOTYPE/_cms/formats/components/sideNavigation](https://walledev.it.utsa.edu/entity/open.act?id=d1f6412a81736a1b3be11e0611458b58&type=format)