### PR TITLE
560 dls action button display issue when wraps to two lines

### DIFF
--- a/components/01-visual-styling/02-button/03-angled-button/angled-button.scss
+++ b/components/01-visual-styling/02-button/03-angled-button/angled-button.scss
@@ -37,6 +37,15 @@
 	position: absolute;
 	right: 15px;
 }
+
+/*
+.clip-mask-bottom-right {
+    --notchSize: 2.0rem;
+    clip-path: polygon(100% 0, 100% calc(100% - var(--notchSize)), calc(100% - var(--notchSize)) 100%, 0 100%, 0 0);
+    -webkit-clip-path: polygon(100% 0, 100% calc(100% - var(--notchSize)), calc(100% - var(--notchSize)) 100%, 0 100%, 0 0);
+}
+*/
+
 .action-btn::after {
 	content: '';
 	position: absolute;
@@ -46,10 +55,10 @@
 	width: 75px;
 	height: 100%;
 	z-index: -1;
-	border-top: 0px solid rgba(255, 255, 255, 0.2);
-	border-right: 23px solid rgba(255, 255, 255, 0.2);
-	border-left: 46px solid transparent;
-	border-bottom: 48px solid rgba(255, 255, 255, 0.2);
+	border-top: 0.0rem solid rgba(255, 255, 255, 0.2);
+	border-right: 1.75rem solid rgba(255, 255, 255, 0.2);
+	border-left: 3.0rem solid transparent;
+	border-bottom: 8.0rem solid rgba(255, 255, 255, 0.2);
 }
 .action-btn.darkblue-bg:hover, .action-btn.darkblue-bg:focus {
 	background-color: #d3430d;

--- a/components/02-components/03-card/01-action-card/action-card--long-copy.hbs
+++ b/components/02-components/03-card/01-action-card/action-card--long-copy.hbs
@@ -1,0 +1,16 @@
+<!--Card Component -->
+<div class="content-card-wrapper">
+    <div class="content-card position-relative white-bg">
+        <div class="content-card-img">
+            <img src="{{ path image }}" class="clip-mask-top-right" alt="Content Card Image">
+        </div>
+        <div class="content-card-content position-relative">
+            <a href="#" class="content-card-link">{{heading}} </a>
+            <p class="font-14 blue regular">{{text}}</p>
+            <div class="blue-action-btn">
+                <a href="#" class="action-btn">A long two line action label description for this button that will wrap to at least two lines on mobile screen sizes <i class="fas fa-arrow-right" aria-hidden="true"></i></a>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- End card Component -->

--- a/components/03-sections/05-content-group/00-action-group/action-group.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group.hbs
@@ -11,6 +11,9 @@
                 {{render '@action-card' action merge=true}}
              </div>
             {{/each}}
+             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
+                {{render '@action-card--long-copy' }}
+             </div>
          </div>
      </div>
  </div>


### PR DESCRIPTION
fixes for #560, dropping pixels for REMs seems to fix this for multiple lines

https://utsa-asc.github.io/college-dls/560-dls-action-button-display-issue-when-wraps-to-two-lines/components/detail/action-group--default