### PR TITLE
601 - added .config.json to file name

### DIFF
--- a/components/04-reference-pages/14-internal-error-page/internal-error-page.config.json
+++ b/components/04-reference-pages/14-internal-error-page/internal-error-page.config.json
@@ -1,7 +1,7 @@
 {
 	"title": "500 Internal Error Page",
     "name": "500 internal error page",
-    "status": "wip",
+    "status": "exported",
 	"context": {
 		"breadcrumb": {
 			"title": "500 Internal Error Page"


### PR DESCRIPTION
Changed json file name to **internal-error-page.config.json** to get status to display correctly.

Now would be a good time to finally figure out what's going on with the css in Cascade DLS that is preventing it from working there as well, I guess.  - (That's sep from working here in DLS)