### PR TITLE
Action Cards - Make 4 per row on larger devices

### DIFF
--- a/components/02-components/03-card/01-action-card/action-card--grey.hbs
+++ b/components/02-components/03-card/01-action-card/action-card--grey.hbs
@@ -7,7 +7,6 @@
         <div class="content-card-content position-relative grey-bg px-lg-2">
             <a href="#" class="content-card-link px-lg-2">{{heading}} </a>
             <p class="font-14 blue regular px-lg-2">{{text}}</p>
-            {{render '@angled-button--blue'}}
         </div>
     </div>
 </div>

--- a/components/02-components/03-card/01-action-card/action-card--grey.hbs
+++ b/components/02-components/03-card/01-action-card/action-card--grey.hbs
@@ -4,9 +4,10 @@
         <div class="content-card-img">
             <img src="{{ path image }}" class="clip-mask-top-right" alt="Content Card Image">
         </div>
-        <div class="content-card-content position-relative grey-bg">
-            <a href="#" class="content-card-link">{{heading}} </a>
-            <p class="font-14 blue regular">{{text}}</p>
+        <div class="content-card-content position-relative grey-bg px-lg-2">
+            <a href="#" class="content-card-link px-lg-2">{{heading}} </a>
+            <p class="font-14 blue regular px-lg-2">{{text}}</p>
+            {{render '@angled-button--blue'}}
         </div>
     </div>
 </div>

--- a/components/02-components/03-card/01-action-card/action-card--grey.hbs
+++ b/components/02-components/03-card/01-action-card/action-card--grey.hbs
@@ -1,13 +1,12 @@
 <!--Card Component -->
 <div class="content-card-wrapper">
-    <div class="content-card position-relative white-bg h-100 ">
+    <div class="content-card position-relative white-bg h-100">
         <div class="content-card-img">
             <img src="{{ path image }}" class="clip-mask-top-right" alt="Content Card Image">
         </div>
         <div class="content-card-content position-relative grey-bg">
             <a href="#" class="content-card-link">{{heading}} </a>
             <p class="font-14 blue regular">{{text}}</p>
-            {{render '@angled-button--blue'}}
         </div>
     </div>
 </div>

--- a/components/02-components/03-card/01-action-card/action-card--grey.hbs
+++ b/components/02-components/03-card/01-action-card/action-card--grey.hbs
@@ -7,6 +7,7 @@
         <div class="content-card-content position-relative grey-bg">
             <a href="#" class="content-card-link">{{heading}} </a>
             <p class="font-14 blue regular">{{text}}</p>
+            {{render '@angled-button--blue'}}
         </div>
     </div>
 </div>

--- a/components/02-components/03-card/01-action-card/action-card.hbs
+++ b/components/02-components/03-card/01-action-card/action-card.hbs
@@ -4,7 +4,7 @@
         <div class="content-card-img">
             <img src="{{ path image }}" class="clip-mask-top-right" alt="Content Card Image">
         </div>
-        <div class="content-card-content position-relative">
+        <div class="content-card-content position-relative px-lg-2">
             <a href="#" class="content-card-link">{{heading}} </a>
             <p class="font-14 blue regular">{{text}}</p>
             {{render '@angled-button--blue'}}

--- a/components/02-components/03-card/01-action-card/action-card.hbs
+++ b/components/02-components/03-card/01-action-card/action-card.hbs
@@ -5,8 +5,8 @@
             <img src="{{ path image }}" class="clip-mask-top-right" alt="Content Card Image">
         </div>
         <div class="content-card-content position-relative px-lg-2">
-            <a href="#" class="content-card-link">{{heading}} </a>
-            <p class="font-14 blue regular">{{text}}</p>
+            <a href="#" class="content-card-link px-lg-2">{{heading}} </a>
+            <p class="font-14 blue regular px-lg-2">{{text}}</p>
             {{render '@angled-button--blue'}}
         </div>
     </div>

--- a/components/03-sections/05-content-group/00-action-group/action-group--compact-grey.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group--compact-grey.hbs
@@ -1,0 +1,17 @@
+<section class="py-5 our-faculty-sec position-relative z-index-0 half-bg-shape">
+    <div class="container">
+        <div class="action-card-list-compact">
+            <div class="inner-sec-headings">
+                <h3 class="h4">A Compact Group of Action Cards</h3>
+            </div>
+            <div class="row">
+                {{#each cards as |action|}}
+                <div class="col-lg-3 col-md-6 col-sm-12">
+                    {{render '@action-card--grey' action merge=true}}
+                </div>
+                {{/each}}
+            </div>
+        </div>
+    </div>
+</section>
+

--- a/components/03-sections/05-content-group/00-action-group/action-group--compact-grey.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group--compact-grey.hbs
@@ -2,7 +2,7 @@
     <div class="container">
             <div class="row">
                 {{#each cards as |action|}}
-                <div class="col-lg-3 col-md-6 col-sm-12">
+                <div class="col-lg-3 col-md-4 col-sm-12">
                     {{render '@action-card--grey' action merge=true}}
                 </div>
                 {{/each}}

--- a/components/03-sections/05-content-group/00-action-group/action-group--compact-grey.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group--compact-grey.hbs
@@ -1,6 +1,5 @@
-<section class="py-5 position-relative z-index-0 half-bg-shape">
+<section class="py-5 content-listing">
     <div class="container">
-        <div class="action-card-list-compact">
             <div class="row">
                 {{#each cards as |action|}}
                 <div class="col-lg-3 col-md-6 col-sm-12">
@@ -8,7 +7,6 @@
                 </div>
                 {{/each}}
             </div>
-        </div>
     </div>
 </section>
 

--- a/components/03-sections/05-content-group/00-action-group/action-group--compact-grey.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group--compact-grey.hbs
@@ -1,9 +1,6 @@
-<section class="py-5 our-faculty-sec position-relative z-index-0 half-bg-shape">
+<section class="py-5 position-relative z-index-0 half-bg-shape">
     <div class="container">
         <div class="action-card-list-compact">
-            <div class="inner-sec-headings">
-                <h3 class="h4">A Compact Group of Action Cards</h3>
-            </div>
             <div class="row">
                 {{#each cards as |action|}}
                 <div class="col-lg-3 col-md-6 col-sm-12">

--- a/components/03-sections/05-content-group/00-action-group/action-group--compact.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group--compact.hbs
@@ -1,6 +1,5 @@
-<section class="py-5 position-relative z-index-0 half-bg-shape">
+<section class="py-5 content-listing">
     <div class="container">
-        <div class="action-card-list-compact">
             <div class="row">
                 {{#each cards as |action|}}
                 <div class="col-lg-3 col-md-6 col-sm-12">
@@ -8,6 +7,5 @@
                 </div>
                 {{/each}}
             </div>
-        </div>
     </div>
 </section>

--- a/components/03-sections/05-content-group/00-action-group/action-group--compact.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group--compact.hbs
@@ -2,7 +2,7 @@
     <div class="container">
             <div class="row">
                 {{#each cards as |action|}}
-                <div class="col-lg-3 col-md-6 col-sm-12">
+                <div class="col-lg-3 col-md-4 col-sm-12">
                     {{render '@action-card' action merge=true}}
                 </div>
                 {{/each}}

--- a/components/03-sections/05-content-group/00-action-group/action-group--compact.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group--compact.hbs
@@ -1,9 +1,6 @@
-<section class="py-5 our-faculty-sec position-relative z-index-0 half-bg-shape">
+<section class="py-5 position-relative z-index-0 half-bg-shape">
     <div class="container">
         <div class="action-card-list-compact">
-            <div class="inner-sec-headings">
-                <h3 class="h4">A Compact Group of Action Cards</h3>
-            </div>
             <div class="row">
                 {{#each cards as |action|}}
                 <div class="col-lg-3 col-md-6 col-sm-12">

--- a/components/03-sections/05-content-group/00-action-group/action-group--compact.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group--compact.hbs
@@ -1,0 +1,16 @@
+<section class="py-5 our-faculty-sec position-relative z-index-0 half-bg-shape">
+    <div class="container">
+        <div class="action-card-list-compact">
+            <div class="inner-sec-headings">
+                <h3 class="h4">A Compact Group of Action Cards</h3>
+            </div>
+            <div class="row">
+                {{#each cards as |action|}}
+                <div class="col-lg-3 col-md-6 col-sm-12">
+                    {{render '@action-card' action merge=true}}
+                </div>
+                {{/each}}
+            </div>
+        </div>
+    </div>
+</section>

--- a/components/03-sections/05-content-group/00-action-group/action-group--grey.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group--grey.hbs
@@ -1,21 +1,7 @@
  <div class="py-5 content-listing">
      <div class="container">
          <div class="row justify-content-lg-center">
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card--grey' action merge=true}}
-            </div>
-            {{/each}}
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card--grey' action merge=true}}
-            </div>
-            {{/each}}
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card--grey' action merge=true}}
-            </div>
-            {{/each}}
+            <h5 class="d-none d-lg-block mb-4">Option: Four cards in a row on larger displays</h5>
             {{#each cards as |action|}}
             <div class="col-lg-3 col-md-6 col-sm-12">
                {{render '@action-card--grey' action merge=true}}
@@ -37,7 +23,24 @@
             </div>
             {{/each}}
          </div>
-         
+         <div class="row justify-content-lg-center">
+            <h5 class="d-none d-lg-block mb-4">Option: Three cards in a row on larger displays</h5>
+            {{#each cards as |action|}}
+            <div class="col-lg-4 col-md-6 col-sm-12">
+               {{render '@action-card--grey' action merge=true}}
+            </div>
+            {{/each}}
+            {{#each cards as |action|}}
+            <div class="col-lg-4 col-md-6 col-sm-12">
+               {{render '@action-card--grey' action merge=true}}
+            </div>
+            {{/each}}
+            {{#each cards as |action|}}
+            <div class="col-lg-4 col-md-6 col-sm-12">
+               {{render '@action-card--grey' action merge=true}}
+            </div>
+            {{/each}}
+         </div>
 
      </div>
  </div>

--- a/components/03-sections/05-content-group/00-action-group/action-group--grey.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group--grey.hbs
@@ -1,4 +1,4 @@
- <div class="py-5 content-listing">
+<section class="py-5 content-listing">
      <div class="container">
          <div class="row">
             {{#each cards as |action|}}
@@ -9,4 +9,4 @@
          </div>
 
      </div>
- </div>
+ </section>

--- a/components/03-sections/05-content-group/00-action-group/action-group--grey.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group--grey.hbs
@@ -1,40 +1,6 @@
  <div class="py-5 content-listing">
      <div class="container">
-         <div class="row justify-content-lg-center">
-            <h5 class="d-none d-lg-block mb-4">Option: Four cards in a row on larger displays</h5>
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card--grey' action merge=true}}
-            </div>
-            {{/each}}
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card--grey' action merge=true}}
-            </div>
-            {{/each}}
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card--grey' action merge=true}}
-            </div>
-            {{/each}}
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card--grey' action merge=true}}
-            </div>
-            {{/each}}
-         </div>
-         <div class="row justify-content-lg-center">
-            <h5 class="d-none d-lg-block mb-4">Option: Three cards in a row on larger displays</h5>
-            {{#each cards as |action|}}
-            <div class="col-lg-4 col-md-6 col-sm-12">
-               {{render '@action-card--grey' action merge=true}}
-            </div>
-            {{/each}}
-            {{#each cards as |action|}}
-            <div class="col-lg-4 col-md-6 col-sm-12">
-               {{render '@action-card--grey' action merge=true}}
-            </div>
-            {{/each}}
+         <div class="row">
             {{#each cards as |action|}}
             <div class="col-lg-4 col-md-6 col-sm-12">
                {{render '@action-card--grey' action merge=true}}

--- a/components/03-sections/05-content-group/00-action-group/action-group--grey.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group--grey.hbs
@@ -1,17 +1,43 @@
  <div class="py-5 content-listing">
      <div class="container">
-         <div class="row">
+         <div class="row justify-content-lg-center">
             {{#each cards as |action|}}
-             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
-                {{render '@action-card--grey' action merge=true}}
-             </div>
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card--grey' action merge=true}}
+            </div>
             {{/each}}
             {{#each cards as |action|}}
-             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
-                {{render '@action-card--grey' action merge=true}}
-             </div>
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card--grey' action merge=true}}
+            </div>
+            {{/each}}
+            {{#each cards as |action|}}
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card--grey' action merge=true}}
+            </div>
+            {{/each}}
+            {{#each cards as |action|}}
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card--grey' action merge=true}}
+            </div>
+            {{/each}}
+            {{#each cards as |action|}}
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card--grey' action merge=true}}
+            </div>
+            {{/each}}
+            {{#each cards as |action|}}
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card--grey' action merge=true}}
+            </div>
+            {{/each}}
+            {{#each cards as |action|}}
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card--grey' action merge=true}}
+            </div>
             {{/each}}
          </div>
+         
 
      </div>
  </div>

--- a/components/03-sections/05-content-group/00-action-group/action-group.config.json
+++ b/components/03-sections/05-content-group/00-action-group/action-group.config.json
@@ -1,9 +1,33 @@
 {
 	"title": "Action Group",
     "name": "action group",
-    "status": "wip",
+    "status": "exported",
 	"context": {
 		"cards": [
+			{
+				"heading": "Lorem ipsum dolor sit amet, consectetur",
+				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
+				"label": "Action",
+				"image": "/college-dls/utsa/images/card-image.png"
+			},
+			{
+				"heading": "Lorem ipsum dolor sit amet, consectetur",
+				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
+				"label": "Action",
+				"image": "/college-dls/utsa/images/card-image.png"
+			},
+			{
+				"heading": "Lorem ipsum dolor sit amet, consectetur",
+				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
+				"label": "Action",
+				"image": "/college-dls/utsa/images/card-image.png"
+			},
+			{
+				"heading": "Lorem ipsum dolor sit amet, consectetur",
+				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
+				"label": "Action",
+				"image": "/college-dls/utsa/images/card-image.png"
+			},
 			{
 				"heading": "Lorem ipsum dolor sit amet, consectetur",
 				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",

--- a/components/03-sections/05-content-group/00-action-group/action-group.config.json
+++ b/components/03-sections/05-content-group/00-action-group/action-group.config.json
@@ -9,6 +9,24 @@
 				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
 				"label": "Action",
 				"image": "/college-dls/utsa/images/card-image.png"
+			},
+			{
+				"heading": "Lorem ipsum dolor sit amet, consectetur",
+				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
+				"label": "Action",
+				"image": "/college-dls/utsa/images/card-image.png"
+			},
+			{
+				"heading": "Lorem ipsum dolor sit amet, consectetur",
+				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
+				"label": "Action",
+				"image": "/college-dls/utsa/images/card-image.png"
+			},
+			{
+				"heading": "Lorem ipsum dolor sit amet, consectetur",
+				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
+				"label": "Action",
+				"image": "/college-dls/utsa/images/card-image.png"
 			}
 		]
 	},
@@ -17,6 +35,14 @@
 		{
 			"name": "default",
 			"label": "Default"
-		}
+		},
+		{
+            "name": "compact",
+            "label": "Compact"
+        },
+		{
+            "name": "compact-grey",
+            "label": "Compact Grey"
+        }
 	]
 }

--- a/components/03-sections/05-content-group/00-action-group/action-group.config.json
+++ b/components/03-sections/05-content-group/00-action-group/action-group.config.json
@@ -1,24 +1,12 @@
 {
 	"title": "Action Group",
     "name": "action group",
-    "status": "exported",
+    "status": "wip",
 	"context": {
 		"cards": [
 			{
 				"heading": "Lorem ipsum dolor sit amet, consectetur",
 				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
-				"label": "Action",
-				"image": "/college-dls/utsa/images/card-image.png"
-			},
-			{
-				"heading": "Lorem ipsum dolor sit amet, consectetur",
-				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet",
-				"label": "Action",
-				"image": "/college-dls/utsa/images/card-image.png"
-			},
-			{
-				"heading": "Lorem ipsum dolor sit amet, consectetur",
-				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet",
 				"label": "Action",
 				"image": "/college-dls/utsa/images/card-image.png"
 			}

--- a/components/03-sections/05-content-group/00-action-group/action-group.config.json
+++ b/components/03-sections/05-content-group/00-action-group/action-group.config.json
@@ -33,8 +33,8 @@
 	"default": "default",
 	"variants": [
 		{
-			"name": "default",
-			"label": "Default"
+			"name": "grey",
+			"label": "Grey"
 		},
 		{
             "name": "compact",

--- a/components/03-sections/05-content-group/00-action-group/action-group.config.json
+++ b/components/03-sections/05-content-group/00-action-group/action-group.config.json
@@ -51,6 +51,30 @@
 				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
 				"label": "Action",
 				"image": "/college-dls/utsa/images/card-image.png"
+			},
+			{
+				"heading": "Lorem ipsum dolor sit amet, consectetur",
+				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
+				"label": "Action",
+				"image": "/college-dls/utsa/images/card-image.png"
+			},
+			{
+				"heading": "Lorem ipsum dolor sit amet, consectetur",
+				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
+				"label": "Action",
+				"image": "/college-dls/utsa/images/card-image.png"
+			},
+			{
+				"heading": "Lorem ipsum dolor sit amet, consectetur",
+				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
+				"label": "Action",
+				"image": "/college-dls/utsa/images/card-image.png"
+			},
+			{
+				"heading": "Lorem ipsum dolor sit amet, consectetur",
+				"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vel purus ut arcu tempor mollis vitae sit amet nulla. Morbi quis interdum odio, ut hendrerit",
+				"label": "Action",
+				"image": "/college-dls/utsa/images/card-image.png"
 			}
 		]
 	},

--- a/components/03-sections/05-content-group/00-action-group/action-group.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group.hbs
@@ -1,43 +1,12 @@
  <div class="py-5 content-listing">
      <div class="container">
-         <div class="row justify-content-lg-center">
-            <h5 class="d-none d-lg-block mb-4">Option: Four cards in a row on larger displays</h5>
+         <div class="row">
             {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card' action merge=true}}
-            </div>
-            {{/each}}
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card' action merge=true}}
-            </div>
-            {{/each}}
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card' action merge=true}}
-            </div>
-            {{/each}}
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
+            <div class="col-lg-4 col-md-6 col-sm-12">
                {{render '@action-card' action merge=true}}
             </div>
             {{/each}}
          </div>
-         <div class="row justify-content-lg-center">
-            <h5 class="d-none d-lg-block mb-4">Option: Three Cards in a row on larger displays</h5>
-            {{#each cards as |action|}}
-            <div class="col-lg-4 col-md-6 col-sm-12">
-               {{render '@action-card' action merge=true}}
-            </div>
-            {{/each}}
-            {{#each cards as |action|}}
-            <div class="col-lg-4 col-md-6 col-sm-12">
-               {{render '@action-card' action merge=true}}
-            </div>
-            {{/each}}
-            <div class="col-lg-4 col-md-6 col-sm-12">
-               {{render '@action-card--long-copy' }}
-            </div>
          </div>
      </div>
  </div>

--- a/components/03-sections/05-content-group/00-action-group/action-group.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group.hbs
@@ -1,4 +1,4 @@
- <div class="py-5 content-listing">
+<section class="py-5 content-listing">
      <div class="container">
          <div class="row">
             {{#each cards as |action|}}
@@ -9,4 +9,4 @@
          </div>
          </div>
      </div>
- </div>
+ </section>

--- a/components/03-sections/05-content-group/00-action-group/action-group.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group.hbs
@@ -1,19 +1,42 @@
  <div class="py-5 content-listing">
      <div class="container">
-         <div class="row">
+         <div class="row justify-content-lg-center">
             {{#each cards as |action|}}
-             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
-                {{render '@action-card' action merge=true}}
-             </div>
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card' action merge=true}}
+            </div>
             {{/each}}
             {{#each cards as |action|}}
-             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
-                {{render '@action-card' action merge=true}}
-             </div>
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card' action merge=true}}
+            </div>
             {{/each}}
-             <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-6 col-sm-12">
-                {{render '@action-card--long-copy' }}
-             </div>
+            {{#each cards as |action|}}
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card' action merge=true}}
+            </div>
+            {{/each}}
+            {{#each cards as |action|}}
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card' action merge=true}}
+            </div>
+            {{/each}}
+            {{#each cards as |action|}}
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card' action merge=true}}
+            </div>
+            {{/each}}
+            {{#each cards as |action|}}
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card' action merge=true}}
+            </div>
+            {{/each}}
+            {{#each cards as |action|}}
+            <div class="col-lg-3 col-md-6 col-sm-12">
+               {{render '@action-card' action merge=true}}
+            </div>
+            {{/each}}
          </div>
+         
      </div>
  </div>

--- a/components/03-sections/05-content-group/00-action-group/action-group.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group.hbs
@@ -6,6 +6,7 @@
                {{render '@action-card' action merge=true}}
             </div>
             {{/each}}
+            
          </div>
          </div>
      </div>

--- a/components/03-sections/05-content-group/00-action-group/action-group.hbs
+++ b/components/03-sections/05-content-group/00-action-group/action-group.hbs
@@ -1,21 +1,7 @@
  <div class="py-5 content-listing">
      <div class="container">
          <div class="row justify-content-lg-center">
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card' action merge=true}}
-            </div>
-            {{/each}}
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card' action merge=true}}
-            </div>
-            {{/each}}
-            {{#each cards as |action|}}
-            <div class="col-lg-3 col-md-6 col-sm-12">
-               {{render '@action-card' action merge=true}}
-            </div>
-            {{/each}}
+            <h5 class="d-none d-lg-block mb-4">Option: Four cards in a row on larger displays</h5>
             {{#each cards as |action|}}
             <div class="col-lg-3 col-md-6 col-sm-12">
                {{render '@action-card' action merge=true}}
@@ -37,6 +23,21 @@
             </div>
             {{/each}}
          </div>
-         
+         <div class="row justify-content-lg-center">
+            <h5 class="d-none d-lg-block mb-4">Option: Three Cards in a row on larger displays</h5>
+            {{#each cards as |action|}}
+            <div class="col-lg-4 col-md-6 col-sm-12">
+               {{render '@action-card' action merge=true}}
+            </div>
+            {{/each}}
+            {{#each cards as |action|}}
+            <div class="col-lg-4 col-md-6 col-sm-12">
+               {{render '@action-card' action merge=true}}
+            </div>
+            {{/each}}
+            <div class="col-lg-4 col-md-6 col-sm-12">
+               {{render '@action-card--long-copy' }}
+            </div>
+         </div>
      </div>
  </div>

--- a/components/03-sections/05-content-group/00-action-group/action-group.readme.md
+++ b/components/03-sections/05-content-group/00-action-group/action-group.readme.md
@@ -5,7 +5,7 @@ Original source from [https://utsa-asc.github.io/college-dls/college-dls/referen
 
 Please ensure all the content is consistent (image, heading, blurb, link), otherwise an Action Group may look unbalanced. Please see the [Action Card Component](action-card--default) for additional documentation. 
 
-All Content Group level components are designed to be full width. Depending on the size of the content and images, you may utilize 3 or 4 internal card components within a row.
+All Content Group level components are designed to be full width. Depending on the size of the content and images, you may utilize multiple internal card components within a row.
 
 ## Media Requirements
 - Action Card Image: Our standard image size is 460px (width) by 210px (height), 72 ppi (pixels per inch) jpeg or png.

--- a/components/03-sections/05-content-group/00-action-group/action-group.scss
+++ b/components/03-sections/05-content-group/00-action-group/action-group.scss
@@ -7,7 +7,7 @@
 }
 
 // **** IMPORTANT ****
-// This component imports 3 or 4 instances of action-card component, so all the other styles are coming from 02-components/01-action-card/action-card.scss
+// This component imports multiple instances of action-card component, so all the other styles are coming from 02-components/01-action-card/action-card.scss
 
 
 /* END action-group.scss */

--- a/components/03-sections/05-content-group/00-action-group/action-group.scss
+++ b/components/03-sections/05-content-group/00-action-group/action-group.scss
@@ -6,8 +6,33 @@
     margin-bottom: 20px;
 }
 
+@include media-breakpoint-down(lg) {
+	.action-card {
+		.action-card-list .row>div {
+			margin-bottom: 20px;
+		}
+	}
+}
+
+
+.action-card-list {
+    .row>div{
+        margin-bottom: 38px;
+    }
+}
+
+.action-card-list-compact {
+    .row>div{
+        margin-bottom: 38px;
+    }
+
+    .action-card .action-card-img > img {
+        min-height:250px;
+    }
+}
+
 // **** IMPORTANT ****
-// This component imports 3 instances of action-card component, so all the other styles are coming from 02-components/01-action-card/action-card.scss
+// This component imports 3 or 4 instances of action-card component, so all the other styles are coming from 02-components/01-action-card/action-card.scss
 
 
 /* END action-group.scss */

--- a/components/03-sections/05-content-group/00-action-group/action-group.scss
+++ b/components/03-sections/05-content-group/00-action-group/action-group.scss
@@ -6,31 +6,6 @@
     margin-bottom: 20px;
 }
 
-@include media-breakpoint-down(lg) {
-	.action-card {
-		.action-card-list .row>div {
-			margin-bottom: 20px;
-		}
-	}
-}
-
-
-.action-card-list {
-    .row>div{
-        margin-bottom: 38px;
-    }
-}
-
-.action-card-list-compact {
-    .row>div{
-        margin-bottom: 38px;
-    }
-
-    .action-card .action-card-img > img {
-        min-height:250px;
-    }
-}
-
 // **** IMPORTANT ****
 // This component imports 3 or 4 instances of action-card component, so all the other styles are coming from 02-components/01-action-card/action-card.scss
 


### PR DESCRIPTION
First stab at this....On large and up displays made the cards col-lg-3. Cards also center on large and up displays.

I think the logic in Cascade will need to have this condition for large and up displays -
4 cards in a row: `<div class="col-lg-3 col-md-6 col-sm-12">`
but if
3 cards in a row: `<div class="col-lg-4 col-md-6 col-sm-12">`

But do we make it a users choice? An option to choose between 3 or 4 cards per row in the component block? Or just do it automatically with formatting magic? 
If user has 7 cards, can one row be 4 cards and the other 3 cards?  Probably at that point they would need to make two separate action card components?