### PR TITLE
Added 5up variant

### DIFF
--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -1,0 +1,18 @@
+<section class="quick-fact-wrapper">
+    <div class="container">
+        <div class="row">
+            <div class="offset-lg-1 col-lg-11">
+                <div class="row">
+            {{#each items}}
+            <div class="col-xxl-2 col-xl-2 col-lg-2 col-md-2 col-sm-12">
+                <div class="quick-facts-content">
+                    <h2>{{ headline }}</h2>
+                    <p>{{ text }}</p>
+                </div>
+            </div>
+            {{/each}}
+            </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -1,18 +1,23 @@
 <section class="quick-fact-wrapper">
     <div class="container">
         <div class="row">
-            <div class="col-lg-12 px-0">
-                <div class="row justify-content-center">
-                    {{#each items}}
-                        <div class="col-xxl-2 col-xl-2 col-lg-2 col-md-2 col-sm-12">
-                            <div class="quick-facts-content">
-                                <h2>{{ headline }}</h2>
-                                <p>{{ text }}</p>
-                            </div>
+            {{#each items}}
+                {{#if @first}}
+                    <div class="offset-lg-1 col-lg-2 col-md-2 col-sm-12">
+                        <div class="quick-facts-content">
+                            <h2>{{ headline }}</h2>
+                            <p>{{ text }}</p>
                         </div>
-                    {{/each}}
-                </div>
-            </div>
+                    </div>
+                {{/if}}
+                {{else}}
+                    <div class="col-lg-2 col-md-2 col-sm-12">
+                        <div class="quick-facts-content">
+                            <h2>{{ headline }}</h2>
+                            <p>{{ text }}</p>
+                        </div>
+                    </div>
+            {{/each}}
         </div>
     </div>
 </section>

--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -1,23 +1,21 @@
 <section class="quick-fact-wrapper">
     <div class="container">
         <div class="row">
-            {{#each items}}
-                {{#if @first}}
+            {{#each 5up-first-item}}
                     <div class="offset-lg-1 col-md-2 col-sm-12">
                         <div class="quick-facts-content">
                             <h2>{{ headline }}</h2>
                             <p>{{ text }}</p>
                         </div>
                     </div>
-                    {{#else}}
-                        <div class="col-md-2 col-sm-12">
-                            <div class="quick-facts-content">
-                                <h2>{{ headline }}</h2>
-                                <p>{{ text }}</p>
-                            </div>
-                        </div>
-                    {{/else}}
-                {{/if}}
+            {{/each}}
+            {{#each 5up-other-items}}
+                <div class="col-md-2 col-sm-12">
+                    <div class="quick-facts-content">
+                        <h2>{{ headline }}</h2>
+                        <p>{{ text }}</p>
+                    </div>
+                </div>
             {{/each}}
         </div>
     </div>

--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -4,12 +4,11 @@
             {{#each items}}
                 {{#if @last}}
                     {{else}}
-                        <div class="col-md-2 col-sm-12 
-                            {{#if @first}} offset-md-1 {{/if}}">
-                                <div class="quick-facts-content">
-                                    <h2>{{ headline }}</h2>
-                                    <p>{{ text }}</p>
-                                </div>
+                        <div class="col-md-2 col-sm-12{{#if @first}}offset-md-1{{/if}}">
+                            <div class="quick-facts-content">
+                                <h2>{{ headline }}</h2>
+                                <p>{{ text }}</p>
+                            </div>
                         </div>
                 {{/if}}
             {{/each}}

--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -3,15 +3,15 @@
         <div class="row">
             <div class="offset-lg-1 col-lg-11">
                 <div class="row">
-            {{#each items}}
-            <div class="col-xxl-2 col-xl-2 col-lg-2 col-md-2 col-sm-12">
-                <div class="quick-facts-content">
-                    <h2>{{ headline }}</h2>
-                    <p>{{ text }}</p>
+                    {{#each items}}
+                        <div class="col-xxl-2 col-xl-2 col-lg-2 col-md-2 col-sm-12">
+                            <div class="quick-facts-content">
+                                <h2>{{ headline }}</h2>
+                                <p>{{ text }}</p>
+                            </div>
+                        </div>
+                    {{/each}}
                 </div>
-            </div>
-            {{/each}}
-            </div>
             </div>
         </div>
     </div>

--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row">
             {{#each 5up-first-item}}
-                    <div class="offset-lg-1 col-md-2 col-sm-12">
+                    <div class="offset-md-1 col-md-2 col-sm-12">
                         <div class="quick-facts-content">
                             <h2>{{ headline }}</h2>
                             <p>{{ text }}</p>

--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -1,7 +1,7 @@
 <section class="quick-fact-wrapper">
     <div class="container">
         <div class="row">
-            <div class="offset-lg-1 col-lg-11">
+            <div class="offset-lg-1 col-lg-11 px-0">
                 <div class="row">
                     {{#each items}}
                         <div class="col-xxl-2 col-xl-2 col-lg-2 col-md-2 col-sm-12">

--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -4,7 +4,7 @@
             {{#each items}}
                 {{#if @last}}
                     {{else}}
-                        <div class="col-md-2 col-sm-12{{#if @first}}offset-md-1{{/if}}">
+                        <div class="col-md-2 col-sm-12 {{#if @first}}offset-md-1{{/if}}">
                             <div class="quick-facts-content">
                                 <h2>{{ headline }}</h2>
                                 <p>{{ text }}</p>

--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -3,14 +3,14 @@
         <div class="row">
             {{#each items}}
                 {{#if @last}}
-                {{else}}
-                    <div class="col-md-2 col-sm-12 
-                        {{#if @first}} offset-md-1 {{/if}}">
-                        <div class="quick-facts-content">
-                            <h2>{{ headline }}</h2>
-                            <p>{{ text }}</p>
+                    {{else}}
+                        <div class="col-md-2 col-sm-12 
+                            {{#if @first}} offset-md-1 {{/if}}">
+                                <div class="quick-facts-content">
+                                    <h2>{{ headline }}</h2>
+                                    <p>{{ text }}</p>
+                                </div>
                         </div>
-                    </div>
                 {{/if}}
             {{/each}}
         </div>

--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -3,9 +3,9 @@
         <div class="row">
             {{#each items}}
                 {{#if @last}}
-
                 {{else}}
-                    <div class="col-md-2 col-sm-12 {{#if @first}}offset-md-1{{/if}}">
+                    <div class="col-md-2 col-sm-12 
+                        {{#if @first}} offset-md-1 {{/if}}">
                         <div class="quick-facts-content">
                             <h2>{{ headline }}</h2>
                             <p>{{ text }}</p>

--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -3,20 +3,21 @@
         <div class="row">
             {{#each items}}
                 {{#if @first}}
-                    <div class="offset-lg-1 col-lg-2 col-md-2 col-sm-12">
+                    <div class="offset-lg-1 col-md-2 col-sm-12">
                         <div class="quick-facts-content">
                             <h2>{{ headline }}</h2>
                             <p>{{ text }}</p>
                         </div>
                     </div>
+                    {{#else}}
+                        <div class="col-md-2 col-sm-12">
+                            <div class="quick-facts-content">
+                                <h2>{{ headline }}</h2>
+                                <p>{{ text }}</p>
+                            </div>
+                        </div>
+                    {{/else}}
                 {{/if}}
-                {{else}}
-                    <div class="col-lg-2 col-md-2 col-sm-12">
-                        <div class="quick-facts-content">
-                            <h2>{{ headline }}</h2>
-                            <p>{{ text }}</p>
-                        </div>
-                    </div>
             {{/each}}
         </div>
     </div>

--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -1,21 +1,17 @@
 <section class="quick-fact-wrapper">
     <div class="container">
         <div class="row">
-            {{#each 5up-first-item}}
-                    <div class="offset-md-1 col-md-2 col-sm-12">
+            {{#each items}}
+                {{#if @last}}
+
+                {{else}}
+                    <div class="col-md-2 col-sm-12 {{#if @first}}offset-md-1{{/if}}">
                         <div class="quick-facts-content">
                             <h2>{{ headline }}</h2>
                             <p>{{ text }}</p>
                         </div>
                     </div>
-            {{/each}}
-            {{#each 5up-other-items}}
-                <div class="col-md-2 col-sm-12">
-                    <div class="quick-facts-content">
-                        <h2>{{ headline }}</h2>
-                        <p>{{ text }}</p>
-                    </div>
-                </div>
+                {{/if}}
             {{/each}}
         </div>
     </div>

--- a/components/03-sections/07-quickfacts/quickfacts--5up.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--5up.hbs
@@ -1,8 +1,8 @@
 <section class="quick-fact-wrapper">
     <div class="container">
         <div class="row">
-            <div class="offset-lg-1 col-lg-11 px-0">
-                <div class="row">
+            <div class="col-lg-12 px-0">
+                <div class="row justify-content-center">
                     {{#each items}}
                         <div class="col-xxl-2 col-xl-2 col-lg-2 col-md-2 col-sm-12">
                             <div class="quick-facts-content">

--- a/components/03-sections/07-quickfacts/quickfacts.config.json
+++ b/components/03-sections/07-quickfacts/quickfacts.config.json
@@ -11,6 +11,16 @@
 			{ "headline": "3K", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
 			{ "headline": "280", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
 			{ "headline": "79%", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" }
+		],
+		
+		"5up-first-item": [
+			{ "headline": "130+", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" }
+		],
+		"5up-other-items": [
+			{ "headline": "9M", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
+			{ "headline": "#2", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
+			{ "headline": "3K", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
+			{ "headline": "280", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" }
 		]
 	},
 	"default": "default",

--- a/components/03-sections/07-quickfacts/quickfacts.config.json
+++ b/components/03-sections/07-quickfacts/quickfacts.config.json
@@ -11,16 +11,6 @@
 			{ "headline": "3K", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
 			{ "headline": "280", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
 			{ "headline": "79%", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" }
-		],
-		
-		"5up-first-item": [
-			{ "headline": "130+", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" }
-		],
-		"5up-other-items": [
-			{ "headline": "9M", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
-			{ "headline": "#2", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
-			{ "headline": "3K", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
-			{ "headline": "280", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" }
 		]
 	},
 	"default": "default",

--- a/components/03-sections/07-quickfacts/quickfacts.config.json
+++ b/components/03-sections/07-quickfacts/quickfacts.config.json
@@ -8,7 +8,7 @@
 			{ "headline": "130+", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
 			{ "headline": "9M", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
 			{ "headline": "#2", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
-			{ "headline": "3,834", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
+			{ "headline": "3K", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
 			{ "headline": "280", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
 			{ "headline": "79%", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit" }
 		]
@@ -30,6 +30,10 @@
 		{
 			"name": "4up",
 			"label": "4up"
+		},
+		{
+			"name": "5up",
+			"label": "5up"
 		},
 		{
 			"name": "6up",

--- a/components/03-sections/07-quickfacts/quickfacts.scss
+++ b/components/03-sections/07-quickfacts/quickfacts.scss
@@ -154,7 +154,7 @@
     }
 // For DLS ONLY ==> 5-Up Variant - removes last column from 6-up layout 
     @include media-breakpoint-up(lg) {
-        .offset-lg-1.col-lg-11 div+div:last-child {
+        .col-lg-12 div+div:last-child {
 			display: none;
         }
     }

--- a/components/03-sections/07-quickfacts/quickfacts.scss
+++ b/components/03-sections/07-quickfacts/quickfacts.scss
@@ -3,147 +3,163 @@
 
 //default color, white background
 .quick-fact-wrapper {
-	overflow: hidden;
-	position: relative;
-	z-index: 0;
-	padding-top: 50px;
-	padding-bottom: 50px;
-	padding: 30px 0px 40px 0px;
-	position: relative;
+    overflow: hidden;
+    position: relative;
+    z-index: 0;
+    padding-top: 50px;
+    padding-bottom: 50px;
+    padding: 30px 0px 40px 0px;
+    position: relative;
 
-	::after {
-		content: '';
-		background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 384 512'%3E%3Cdefs%3E%3Cstyle%3E.fa-secondary%7Bopacity:1.0%7D%3C/style%3E%3C/defs%3E%3Cpath class='fa-secondary' d='M352 256c-8.188 0-16.38-3.125-22.62-9.375L192 109.3L54.63 246.6c-12.5 12.5-32.75 12.5-45.25 0s-12.5-32.75 0-45.25l160-160c12.5-12.5 32.75-12.5 45.25 0l160 160c12.5 12.5 12.5 32.75 0 45.25C368.4 252.9 360.2 256 352 256z'/%3E%3Cpath class='fa-secondary' d='M352 448c-8.188 0-16.38-3.125-22.62-9.375L192 301.3l-137.4 137.4c-12.5 12.5-32.75 12.5-45.25 0s-12.5-32.75 0-45.25l160-160c12.5-12.5 32.75-12.5 45.25 0l160 160c12.5 12.5 12.5 32.75 0 45.25C368.4 444.9 360.2 448 352 448z'/%3E%3C/svg%3E");
-		background-repeat: no-repeat;
-		background-size: contain;
-		position: absolute;
-		right: 0;
-		top: 0;
-		bottom: 0;
-		z-index: -10;
-		opacity: 0.007;
-		width: 100%;
-		height: 100%;
-		overflow: hidden;
-	}
+    ::after {
+        content: '';
+        background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 384 512'%3E%3Cdefs%3E%3Cstyle%3E.fa-secondary%7Bopacity:1.0%7D%3C/style%3E%3C/defs%3E%3Cpath class='fa-secondary' d='M352 256c-8.188 0-16.38-3.125-22.62-9.375L192 109.3L54.63 246.6c-12.5 12.5-32.75 12.5-45.25 0s-12.5-32.75 0-45.25l160-160c12.5-12.5 32.75-12.5 45.25 0l160 160c12.5 12.5 12.5 32.75 0 45.25C368.4 252.9 360.2 256 352 256z'/%3E%3Cpath class='fa-secondary' d='M352 448c-8.188 0-16.38-3.125-22.62-9.375L192 301.3l-137.4 137.4c-12.5 12.5-32.75 12.5-45.25 0s-12.5-32.75 0-45.25l160-160c12.5-12.5 32.75-12.5 45.25 0l160 160c12.5 12.5 12.5 32.75 0 45.25C368.4 444.9 360.2 448 352 448z'/%3E%3C/svg%3E");
+        background-repeat: no-repeat;
+        background-size: contain;
+        position: absolute;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        z-index: -10;
+        opacity: 0.007;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+    }
 
-	.row {
-		margin: 0px;
-	}
+    .row {
+        margin: 0px;
+    }
 
-	.quick-facts-content {
-		text-align: center;
-		z-index:100;
+    .quick-facts-content {
+        text-align: center;
+        z-index: 100;
 
-		h2 {
-			font-family: "kulturista-web", serif;
-			font-weight: 700;
-			margin-bottom: 20px;
-			font-size: 4.5rem;
-		}
+        h2 {
+            font-family: "kulturista-web", serif;
+            font-weight: 700;
+            margin-bottom: 20px;
+            font-size: 4.5rem;
+        }
 
-		p {
-			font-size: 1.2rem;
-			font-weight: 600;
-			width: 100%;
-			line-height: normal;
-		}
-	}
-	.department-heading {
-		margin-bottom: 30px;
-	}
+        p {
+            font-size: 1.2rem;
+            font-weight: 600;
+            width: 100%;
+            line-height: normal;
+        }
+    }
 
-	h3 {
-		color: $blue;
-	}
+    .department-heading {
+        margin-bottom: 30px;
+    }
 
-	.quick-facts-content h2 {
-		color: $orange-a11y;
-	}
+    h3 {
+        color: $blue;
+    }
 
-	.quick-facts-content p {
-		color: $blue;
-	}
+    .quick-facts-content h2 {
+        color: $orange-a11y;
+    }
 
-	&.blue-bg {
-		::after {
-			opacity: 0.025;
-		}
-	
-		h3 {
-			color: $white;
-		}
-	
-		.quick-facts-content {
-			h2 {
-				color: $orange-a11y;
-			}
-	
-			p {
-				color: $white;
-			}
-		}
-	}
+    .quick-facts-content p {
+        color: $blue;
+    }
 
-	&.grey-bg {
-		::after {
-			opacity: 0.005;
-		}
-	
-		h3 {
-			color: $blue;
-		}
-	
-		.quick-facts-content {
-			h2 {
-				color: $orange-a11y;
-			}
-			p {
-				color: $blue;
-			}
-		}
-	}
+    &.blue-bg {
+        ::after {
+            opacity: 0.025;
+        }
 
-	&.orange-a11y-bg {
-		background-color: $orange-a11y;
-		h3 {
-			color: $white;
-		}
-		.quick-facts-content {
-			h2 {
-				color: $blue;
-			}
-			p {
-				color: $white;
-			}
-		}
-	}
+        h3 {
+            color: $white;
+        }
 
-	@include media-breakpoint-down(lg) {
-		.quick-facts-content {
-			h2 {
-				font-size: 3.2rem;
-			}
-			p {
-				font-size: 1.0rem;
-			}
-		}
-	}
-	
-	@include media-breakpoint-down(md) {
-		padding-top: 30px;
-		padding-bottom: 30px;
+        .quick-facts-content {
+            h2 {
+                color: $orange-a11y;
+            }
 
-		.quick-facts-content {
-			h2 {
-				font-size: 3.5rem;
-			}
+            p {
+                color: $white;
+            }
+        }
+    }
 
-			p {
-				font-size: 1.1rem;
-			}
-		}
-	}
+    &.grey-bg {
+        ::after {
+            opacity: 0.005;
+        }
+
+        h3 {
+            color: $blue;
+        }
+
+        .quick-facts-content {
+            h2 {
+                color: $orange-a11y;
+            }
+
+            p {
+                color: $blue;
+            }
+        }
+    }
+
+    &.orange-a11y-bg {
+        background-color: $orange-a11y;
+
+        h3 {
+            color: $white;
+        }
+
+        .quick-facts-content {
+            h2 {
+                color: $blue;
+            }
+
+            p {
+                color: $white;
+            }
+        }
+    }
+
+    @include media-breakpoint-down(lg) {
+
+        .quick-facts-content {
+            h2 {
+                font-size: 3.2rem;
+            }
+
+            p {
+                font-size: 1.0rem;
+            }
+        }
+
+    }
+
+    @include media-breakpoint-down(md) {
+        padding-top: 30px;
+        padding-bottom: 30px;
+
+        .quick-facts-content {
+            h2 {
+                font-size: 3.5rem;
+            }
+
+            p {
+                font-size: 1.1rem;
+            }
+        }
+    }
+	// For DLS ONLY ==> 5-Up Variant - removes last column from 6-up layout 
+    @include media-breakpoint-up(lg) {
+        .offset-lg-1.col-lg-11 div+div:last-child {
+			display: none;
+        }
+    }
+// END: For DLS ONLY ==> 5-Up Variant - removes last column from 6-up layout 
+
 }
 
 /* END quickfacts.scss */

--- a/components/03-sections/07-quickfacts/quickfacts.scss
+++ b/components/03-sections/07-quickfacts/quickfacts.scss
@@ -152,7 +152,7 @@
             }
         }
     }
-	// For DLS ONLY ==> 5-Up Variant - removes last column from 6-up layout 
+// For DLS ONLY ==> 5-Up Variant - removes last column from 6-up layout 
     @include media-breakpoint-up(lg) {
         .offset-lg-1.col-lg-11 div+div:last-child {
 			display: none;

--- a/components/03-sections/07-quickfacts/quickfacts.scss
+++ b/components/03-sections/07-quickfacts/quickfacts.scss
@@ -152,14 +152,6 @@
             }
         }
     }
-// For DLS ONLY ==> 5-Up Variant - removes last column from 6-up layout 
-    @include media-breakpoint-up(lg) {
-        .col-lg-12 div+div:last-child {
-			display: none;
-        }
-    }
-// END: For DLS ONLY ==> 5-Up Variant - removes last column from 6-up layout 
-
 }
 
 /* END quickfacts.scss */


### PR DESCRIPTION
Added 5up variant. It has SCSS that removes last child from 6up display that is only needed for DLS (do not need to bring into  CMS...I don't think, anyway.)

<img width="1865" alt="Screenshot 2023-11-29 at 12 13 51 PM" src="https://github.com/utsa-asc/college-dls/assets/92815346/683ccff9-255f-4680-b921-79dbb2c52fc4">
