### PR TITLE
Updated lists CSS so styles are applied without classes

### DIFF
--- a/components/01-visual-styling/01-typography/05-ordered-list/ordered-list--alt.hbs
+++ b/components/01-visual-styling/01-typography/05-ordered-list/ordered-list--alt.hbs
@@ -1,16 +1,23 @@
+<section class="page-text-wrapper">
 <div class="container">
         <div class="row no-mrg">
             <div class="col-xl-col-lg-6 col-md-6 col-sm-12">
                 <div class="enhanced-ordered-list">
                     <ol class="enhanced-ol-list">
-                        <li class="list-item">{{ text }}</li>
-                        <li class="list-item">Use the HTML &lt;ol&gt; element to define an ordered list</li>
-                        <li class="list-item">Use the HTML type attribute to define the numbering type</li>
-                        <li class="list-item">Use the HTML &lt;li&gt; element to define a list item</li>
-                        <li class="list-item">Lists can be nested</li>
-                        <li class="list-item">List items can contain other HTML elements</li>
+                        <li>{{ text }}</li>
+                        <li>Use the HTML &lt;ol&gt; element to define an ordered list</li>
+                        <li>Use the HTML type attribute to define the numbering type</li>
+                        <li>Use the HTML &lt;li&gt; element to define a list item</li>
+                        <li>Lists can be nested
+                            <ul><li>Nested item.</li>
+                            <li>Nested item.</li>
+                            <li>Nested item.</li>
+                        </ul>
+                        </li>
+                        <li>List items can contain other HTML elements</li>
                     </ol>
                 </div>
             </div>
         </div>
 </div>
+</section>

--- a/components/01-visual-styling/01-typography/05-ordered-list/ordered-list.hbs
+++ b/components/01-visual-styling/01-typography/05-ordered-list/ordered-list.hbs
@@ -1,16 +1,23 @@
+<section class="page-text-wrapper">
 <div class="container">
     <div class="row no-mrg">
         <div class="col-xl-col-lg-6 col-md-6 col-sm-12">
-            <div class="ordered-list">
-                <ol class="ol-list">
-                    <li class="list-item">{{ text }}</li>
-                    <li class="list-item">Use the HTML &lt;ol&gt; element to define an ordered list</li>
-                    <li class="list-item">Use the HTML type attribute to define the numbering type</li>
-                    <li class="list-item">Use the HTML &lt;li&gt; element to define a list item</li>
-                    <li class="list-item">Lists can be nested</li>
-                    <li class="list-item">List items can contain other HTML elements</li>
+            <div>
+                <ol>
+                    <li>{{ text }}</li>
+                    <li>Use the HTML &lt;ol&gt; element to define an ordered list</li>
+                    <li>Use the HTML type attribute to define the numbering type</li>
+                    <li>Use the HTML &lt;li&gt; element to define a list item</li>
+                    <li>Lists can be nested
+                        <ul><li>Nested item.</li>
+                            <li>Nested item.</li>
+                            <li>Nested item.</li>
+                        </ul>
+                    </li>
+                    <li>List items can contain other HTML elements</li>
                 </ol>
             </div>
         </div>
     </div>
 </div>
+</section>

--- a/components/01-visual-styling/01-typography/05-ordered-list/ordered-list.scss
+++ b/components/01-visual-styling/01-typography/05-ordered-list/ordered-list.scss
@@ -1,57 +1,37 @@
 /* components/01-visual-styling/03-typography/04-ordered-list/ordered-list.scss */
 /* BEGIN ordered-list.scss */
-.ordered-list .blue-label,
-.enhanced-ordered-list .blue-label {
-	margin-bottom: 24px;
-}
-.ol-list,
-.enhanced-ol-list {
-	padding-left: 20px;
-}
-
-.ol-list li,
-.enhanced-ol-list li {
+.page-text-wrapper ol li, .tab-body-content ol li, .accordion-body-content ol li {
 	margin-bottom: 6px;
 	font-size: 18px;
 	font-weight: 400;
-}
+  }
 
-.enhanced-ol-list li {
+.page-text-wrapper ol > li > ul {
+	margin-top: 7px;
+  }
+
+  .ordered-list .blue-label,
+  .enhanced-ordered-list .blue-label {
+	margin-bottom: 24px;
+  }
+  
+  .enhanced-ol-list {
+	padding-left: 20px;
+  }
+  
+  .enhanced-ol-list li {
+	margin-bottom: 6px;
+	font-size: 18px;
+	font-weight: 400;
+  }
+  
+  .enhanced-ol-list li {
 	margin-bottom: 10px;
 	font-family: "kulturista-web", serif;
-}
-
-.enhanced-ol-list::marker {
-	color: $orange-a11y;
- }
-
-.ul-list li {
-	margin-bottom: 7px;
-}
-
-.ul-inner-list {
-	list-style: none;
-}
-
-.ul-inner-list>li {
-	position: relative;
-	padding-top: 7px;
-	margin-bottom: 0px !important;
-}
-
-.ul-inner-list>li::before {
-	content: '⁃';
-	position: absolute;
-	left: -23px;
-	font-weight: 700;
-}
-
-.enhanced-ul-list li {
-	margin-bottom: 7px;
-}
-
-.enhanced-ul-list li .color-orange {
-	margin-right: 10px;
-}
+  }
+  
+  .enhanced-ol-list::marker {
+	color: #D3430D;
+  }
 
 /* END ordered-list.scss */

--- a/components/01-visual-styling/01-typography/06-unordered-list/unordered-list.hbs
+++ b/components/01-visual-styling/01-typography/06-unordered-list/unordered-list.hbs
@@ -1,18 +1,21 @@
+<section class="page-text-wrapper">
 <div class="container">
-    <div class="">
-        <div class="row no-mrg">
-            <div class="col-xl-col-lg-6 col-md-6 col-sm-12">
-                <div class="unordered-list">
-                    <ul class="ul-list">
-                        <li class="list-item">{{ text }}</li>
-                        <li class="list-item">Use the HTML &lt;ul&gt; element to define an unordered list</li>
-                        <li class="list-item">Use the HTML type attribute to define the numbering type</li>
-                        <li class="list-item">Use the HTML &lt;li&gt; element to define a list item</li>
-                        <li class="list-item">Lists can be nested</li>
-                        <li class="list-item">List items can contain other HTML elements</li>
+    <div class="row no-mrg">
+        <div class="col-xl-col-lg-6 col-md-6 col-sm-12">
+            <ul>
+                <li>{{ text }}</li>
+                <li>Use the HTML &lt;ul&gt; element to define an unordered list</li>
+                <li>Use the HTML type attribute to define the numbering type</li>
+                <li>Use the HTML &lt;li&gt; element to define a list item</li>
+                <li>Lists can be nested
+                    <ul><li>Nested item.</li>
+                        <li>Nested item.</li>
+                        <li>Nested item.</li>
                     </ul>
-                </div>
-            </div>
+                </li>
+                <li>List items can contain other HTML elements</li>
+            </ul>
         </div>
     </div>
 </div>
+</section>

--- a/components/01-visual-styling/01-typography/06-unordered-list/unordered-list.scss
+++ b/components/01-visual-styling/01-typography/06-unordered-list/unordered-list.scss
@@ -1,5 +1,19 @@
 /* components/01-visual-styling/03-typography/05-unordered-list/unordered-list.scss */
 /* BEGIN unordered-list.scss */
+.page-text-wrapper ul li, .tab-body-content ul li, .accordion-body-content ul li {
+    margin-bottom: 7px;
+  }
 
+.page-text-wrapper ul > li > ul {
+	margin-top: 7px;
+  }
+  
+  .enhanced-ul-list li {
+    margin-bottom: 7px;
+  }
+  
+  .enhanced-ul-list li .color-orange {
+    margin-right: 10px;
+  }
 
 /* END unordered-list.scss */

--- a/components/03-sections/02-navigation/03-side-navigation/side-navigation.scss
+++ b/components/03-sections/02-navigation/03-side-navigation/side-navigation.scss
@@ -64,6 +64,7 @@
 
 		.nav-item {
 			position: relative;
+			margin-bottom: 0;
 			//unset normal bootstrap ::after look/feel
 			.dropdown-toggle::after {
 				content: unset;

--- a/components/04-reference-pages/12-stacked-testing/stacked-testing.hbs
+++ b/components/04-reference-pages/12-stacked-testing/stacked-testing.hbs
@@ -40,6 +40,59 @@
     {{ render '@call-to-action-media' cta-media-context }}
     {{ render '@call-to-action-media--blue' cta-media-context }}
 
+    <section class="page-text-wrapper" id="skipToContent">
+      <div class="container">
+        <div class="row mobile-reverse-order">
+          <div class="col-lg-12 col-md-12 col-sm-12">
+              <h2>Unordered and Ordered List Testing</h2>
+              <h3 class="orange-a11y">UL With Classes Added</h3>
+              <div class="unordered-list"><ul class="ul-list">
+                <li>This is a list item.</li>
+                <li>This is a list item.</li>
+                <li class="ul-inner-list">This is a nested List
+                  <ul><li>This is a list item.</li>
+                      <li>This is a list item.</li>
+                      <li>This is a list item.</li>
+                    </ul>
+                </li>
+                <li>The Policy Studies Center of the College of Public Policy.</li>
+              </ul>
+              </div>
+              <h3 class="orange-a11y">OL With Classes Added</h3>
+              <div class="ordered-list"><ol class="ol-list">
+                <li>This is a list item.</li>
+                <li>This is a list item.</li>
+                <li>This is a list item.</li>
+              </ol>
+              </div>
+          </div>
+          <div class="col-lg-12 col-md-12 col-sm-12">
+              <h2>Unordered and Ordered List Testing</h2>
+              <h3 class="orange-a11y">UL With Classes Scoped to Page</h3>
+              <div><ul>
+                <li>This is a list item.</li>
+                <li>This is a list item.</li>
+                <li>This is a nested List
+                <ul>
+                <li>This is a list item.</li>
+                <li>This is a list item.</li>
+                <li>This is a list item.</li></ul>
+                </li>
+              </ul>
+              </div>
+              <h3 class="orange-a11y">OL With Classes Scoped to Page</h3>
+              <div><ol>
+                <li>This is a list item.</li>
+                <li>This is a list item.</li>
+                <li>This is a list item.</li>
+              </ol>
+              </div>
+              <p>End of Lists.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- END CTA -->
   </main>
   {{ render '@back-to-top' }}  


### PR DESCRIPTION
Updated the list styles so they would be applied to all lists within the body of the page without the need to add a class. Updated side nav CSS to compensate for that. Styles now scoped to lists within the page-text-wrapper.

Kept enhanced list and alt ordered list CSS since those are different.