### PR TITLE
Changed h3 to h2

### DIFF
--- a/components/03-sections/07-quickfacts/quickfacts--grey.hbs
+++ b/components/03-sections/07-quickfacts/quickfacts--grey.hbs
@@ -1,7 +1,7 @@
 <section class="quick-fact-wrapper grey-bg">
     <div class="container">
         <div class="department-heading">
-            <h3 class="h3 fw-bold text-center">Department Profile</h3>
+            <h2 class="h3 fw-bold text-center">Department Profile</h2>
         </div>
         <div class="row">
             {{#each_upto items 3}}


### PR DESCRIPTION
It looks like the h3 class was already there, so the size will be the same. The numbers are h2's, so still not technically semantic when the title is added. 