### PR TITLE
cleaning button and controls styling, addresses issue #673

### DIFF
--- a/components/03-sections/03-banner/banner--rotating.hbs
+++ b/components/03-sections/03-banner/banner--rotating.hbs
@@ -1,17 +1,18 @@
 <section class="banner" id="banner-rotating">
    <div class="slider-wrapper ">
       <div class="overlay"></div>
-      <div id="hero-slider" class="carousel slide" data-bs-pause="false" aria-roledescription="carousel" aria-label="slides for content">
+      <div id="hero-slider" class="carousel slide" data-bs-pause="false" aria-roledescription="carousel"
+         aria-label="slides for content">
          <!-- The slideshow -->
          <div class="carousel-inner" aria-live="off">
+            {{#each rotating as |item|}}
             <div class="carousel-item active" role="group" aria-roledescription="slide" aria-label="1 of 4">
-               <div class="hero-banner-slider"
-                  style="background-image: url('{{ path '/college-dls/college/images/slider-bg.png'}}');">
+               <div class="hero-banner-slider" style="background-image: url('{{ path item.image }}');">
                   <div class="container">
                      <div class="hero-banner-content">
-                        <h1 class="banner-heading">{{ banner.text }} <span class="display-block">Or Page Title</span></h1>
-                        <p class="banner-description">Lorem ipsum dolor sit amet, <span
-                              class="display-block">consectetur adipiscing elit.</span></p>
+                        <h1 class="banner-heading">{{ item.text }} <span class="display-block">Or Page Title</span></h1>
+                        <p class="banner-description">{{ item.description }}<span class="display-block">consectetur
+                              adipiscing elit.</span></p>
                         <div class="banner-btns">
                            <a class="orange-btn" href="#">Action</a>
                            <a class="white-btn" href="#">Action</a>
@@ -20,54 +21,7 @@
                   </div>
                </div>
             </div>
-            <div class="carousel-item" role="group" aria-roledescription="slide" aria-label="2 of 4">
-               <div class="hero-banner-slider"
-                  style="background-image: url('{{ path '/college-dls/college/images/hero-banner.png'}}');">
-                  <div class="container">
-                     <div class="hero-banner-content">
-                        <h1 class="banner-heading">{{ banner.text }} <span class="display-block">Or Page Title</span></h1>
-                        <p class="banner-description">Lorem ipsum dolor sit amet, <span
-                              class="display-block">consectetur adipiscing elit.</span></p>
-                        <div class="banner-btns">
-                           <a class="orange-btn" href="#">Action</a>
-                           <a class="white-btn" href="#">Action</a>
-                        </div>
-                     </div>
-                  </div>
-               </div>
-            </div>
-            <div class="carousel-item" role="group" aria-roledescription="slide" aria-label="3 of 4">
-               <div class="hero-banner-slider"
-                  style="background-image: url('{{ path '/college-dls/college/images/slider-bg.png'}}');">
-                  <div class="container">
-                     <div class="hero-banner-content">
-                        <h1 class="banner-heading">{{ banner.text }} <span class="display-block">Or Page Title</span></h1>
-                        <p class="banner-description">Lorem ipsum dolor sit amet, <span
-                              class="display-block">consectetur adipiscing elit.</span></p>
-                        <div class="banner-btns">
-                           <a class="orange-btn" href="#">Action</a>
-                           <a class="white-btn" href="#">Action</a>
-                        </div>
-                     </div>
-                  </div>
-               </div>
-            </div>
-            <div class="carousel-item" role="group" aria-roledescription="slide" aria-label="4 of 4">
-               <div class="hero-banner-slider"
-                  style="background-image: url('{{ path '/college-dls/college/images/hero-banner.png'}}');">
-                  <div class="container">
-                     <div class="hero-banner-content">
-                        <h1 class="banner-heading">College Name <span class="display-block">Or Page Title</span></h1>
-                        <p class="banner-description">Lorem ipsum dolor sit amet, <span
-                              class="display-block">consectetur adipiscing elit.</span></p>
-                        <div class="banner-btns">
-                           <a class="orange-btn" href="#">Action</a>
-                           <a class="white-btn" href="#">Action</a>
-                        </div>
-                     </div>
-                  </div>
-               </div>
-            </div>
+            {{/each}}
          </div>
          <!-- Indicators -->
          <ul class="carousel-indicators container">
@@ -76,8 +30,6 @@
             <li><button data-bs-target="#hero-slider" data-bs-slide-to="1" aria-label="Slide Second">&nbsp;</button>
             </li>
             <li><button data-bs-target="#hero-slider" data-bs-slide-to="2" aria-label="Slide Third">&nbsp;</button></li>
-            <li><button data-bs-target="#hero-slider" data-bs-slide-to="3" aria-label="Slide Fourth">&nbsp;</button>
-            </li>
          </ul>
          <!-- Left and right controls -->
          <a class="carousel-control-prev" href="#hero-slider" data-bs-slide="prev" aria-label="Previous Arrow">
@@ -88,7 +40,8 @@
          </a>
          <div id="carousel-button">
             <div class="carousel-controls" data-click="1">
-               <button id="pauseButton" type="button" class="btn rotation pause" aria-label="pause" aria-label="Stop automatic slide show">
+               <button id="pauseButton" type="button" class="btn rotation pause" aria-label="pause"
+                  aria-label="Stop automatic slide show">
                   <i class="fas fa-pause-circle" aria-hidden="true"></i>
                </button>
             </div>

--- a/components/03-sections/03-banner/banner.config.json
+++ b/components/03-sections/03-banner/banner.config.json
@@ -4,7 +4,24 @@
 	"context": {
 		"banner": {
 			"text": "I am a default banner."
-		}
+		},
+		"rotating": [
+			{
+				"text": "I am a default banner.",
+				"description": "I am a much longer description subheading that goes here",
+				"image": "/college-dls/college/images/placeholders/placeholder-1200-600-blue.svg"
+			},
+			{
+				"text": "I am a default banner.",
+				"description": "I am a much longer description subheading that goes here",
+				"image": "/college-dls/college/images/placeholders/placeholder-1200-600-orange.svg"
+			},
+			{
+				"text": "I am a default banner.",
+				"description": "I am a much longer description subheading that goes here",
+				"image": "/college-dls/college/images/placeholders/placeholder-1200-600-blue.svg"
+			}
+		]
 	},
 	"default": "default",
 	"variants": [

--- a/components/03-sections/03-banner/banner.scss
+++ b/components/03-sections/03-banner/banner.scss
@@ -140,6 +140,8 @@
 			padding-top: 14%;
 			padding-bottom: 21%;
 			background-color: $blue;
+			height: 40rem;
+			min-height: 40rem;
 		}
 
 		.carousel-indicators {
@@ -159,7 +161,7 @@
 			padding-bottom: 0;
 			padding-left: 15px;
 			padding-right: 15px;
-			bottom: 24%;
+			bottom: 1%;
 			z-index: 99;
 		}
 		.carousel-indicators>button.active {
@@ -207,33 +209,35 @@
 	
 		 .carousel-control-prev {
 			width: 8%;
-			height: auto;
+			// height: auto;
 			opacity: 1;
 			z-index: 99;
 		}
 	
 		.carousel .carousel-control-next {
 			width: 8%;
-			height: auto;
+			// height: auto;
 			opacity: 1;
 			z-index: 99;
 		}
 	
-		#carousel-button button {
-			padding: 5px;
-			color: $white;
-			font-size: 29px;
-			line-height: normal;
-			&:focus, &:hover {
-				color: $blue;
-			}
-		}
-	
 		#carousel-button {
 			position: absolute;
-			bottom: 12%;
-			left: 42%;
+			bottom: 3%;
+			right: 15%;
+			// 	bottom: 12%;
+			// left: 42%;
 			z-index: 99;
+
+			button {
+				padding: 5px;
+				color: $white;
+				font-size: 29px;
+				line-height: normal;
+				&:focus, &:hover {
+					color: $blue;
+				}	
+			}
 		}
 	}
 
@@ -260,8 +264,8 @@
 			left: 0;
 			top: 0;
 			bottom: 0;
-			width: 100%;
-			height: 88%;
+			// width: 100%;
+			// height: 88%;
 			z-index: 9;
 			background-repeat: no-repeat;
 		}
@@ -371,19 +375,10 @@
 		max-width: 1009px;
 	}
 
-	#page-hero-carousel #carousel-button {
-		left: 0;
-		max-width: 1009px;
-		margin: 0 auto;
-		width: 100%;
-		right: 0;
-		padding-left: 54px;
-		padding-right: 54px;
-	}
 }
 
 @include media-breakpoint-down(md) {
-		.top-logo-text {
+	.top-logo-text {
 		display: none;
 	}
 
@@ -521,13 +516,13 @@
 		}
 	}
 
-	#carousel-button {
-		position: absolute;
-		bottom: 12%;
-		left: initial;
-		z-index: 99;
-		right: 25px;
-	}
+	// #carousel-button {
+	// 	position: absolute;
+	// 	bottom: 12%;
+	// 	left: initial;
+	// 	z-index: 99;
+	// 	right: 25px;
+	// }
 }
 
 @include media-breakpoint-only(lg) {
@@ -545,9 +540,9 @@
 			padding-bottom: 300px;
 		}
 
-		#carousel-button {
-			left: 50%;
-		}
+		// #carousel-button {
+		// 	left: 50%;
+		// }
 	}
 }
 

--- a/components/03-sections/03-banner/banner.scss
+++ b/components/03-sections/03-banner/banner.scss
@@ -209,24 +209,20 @@
 	
 		 .carousel-control-prev {
 			width: 8%;
-			// height: auto;
-			opacity: 1;
+			opacity: 0.5;
 			z-index: 99;
 		}
 	
-		.carousel .carousel-control-next {
+		.carousel-control-next {
 			width: 8%;
-			// height: auto;
-			opacity: 1;
+			opacity: 0.5;
 			z-index: 99;
 		}
 	
 		#carousel-button {
 			position: absolute;
 			bottom: 3%;
-			right: 15%;
-			// 	bottom: 12%;
-			// left: 42%;
+			right: 9%;
 			z-index: 99;
 
 			button {

--- a/public/college/images/placeholders/placeholder-1200-600-blue.svg
+++ b/public/college/images/placeholders/placeholder-1200-600-blue.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" viewBox="0 0 1200 600">
+  <rect fill="#0c2340" width="1200" height="600"/>
+  <text fill="#d3430d" font-family="sans-serif" font-size="60" dy="42.0" font-weight="bold" x="30%" y="10%" text-anchor="middle">1200x600 - placeholder</text>
+</svg>

--- a/public/college/images/placeholders/placeholder-1200-600-orange.svg
+++ b/public/college/images/placeholders/placeholder-1200-600-orange.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" viewBox="0 0 1200 600">
+  <rect fill="#d3430d" width="1200" height="600"/>
+  <text fill="#0c2340" font-family="sans-serif" font-size="60" dy="42.0" font-weight="bold" x="30%" y="10%" text-anchor="middle">1200x600 - placeholder</text>
+</svg>

--- a/public/college/images/placeholders/placeholder-1600-500.svg
+++ b/public/college/images/placeholders/placeholder-1600-500.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="500" viewBox="0 0 1600 500">
+  <rect fill="#000000" width="1600" height="500"/>
+  <text fill="#7FDBFF" font-family="sans-serif" font-size="30" dy="10.5" font-weight="bold" x="50%" y="50%" text-anchor="middle">1600x500</text>
+</svg>

--- a/src/scss/_vendor.scss
+++ b/src/scss/_vendor.scss
@@ -100,12 +100,6 @@ body {
 	.deadline-card-list .row>div {
 		margin-bottom: 20px;
 	}
-	#carousel-button {
-		left: 0 !important;
-		right: 0 !important;
-		text-align: center;
-		padding: 0px 15px;
-	}
 	.search .dropdown-menu input {
 		padding: 6px 30px 6px 15px;
 	}


### PR DESCRIPTION
- added some placeholder images to test stretching (SVG)
- found some lingering styles from _vendor.scss that was overriding pause button location on some screen sizes
- affixing pause button to the right hand side, more like video, we are restricted with how far right we can go due to the next/back button controls
- affixing the indicator controls to the same line at the bottom
- cleaning up rotating banner hbs to be more hbs
- added dummy context data for rotating to config
- added 40em height to wrapper (.hero-banner-slider) to conform to same ratio as video-banner