### PR TITLE
Replaced Event Card arrow png with FA and CSS

### DIFF
--- a/components/02-components/03-card/02-event-card/event-card--horizontal-blue.hbs
+++ b/components/02-components/03-card/02-event-card/event-card--horizontal-blue.hbs
@@ -13,8 +13,10 @@
                     <a class="event-link-overlay" href="#" aria-label="Event Overlay">&nbsp;</a>
                     <h3 class="h5">{{ headline }}</h3>
                     <p>{{ subheading }}</p>
-                    <div class="right-arrow">
-                        <img src="{{ path '/college-dls/utsa/images/Corner-Arrow.png' }}" alt="Arrow Image">
+                    <div class="event-icon-container">
+                        <div class="event-icon">
+                        <i class="fas fa-arrow-right" aria-hidden="true"></i>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/components/02-components/03-card/02-event-card/event-card--horizontal-image-blue.hbs
+++ b/components/02-components/03-card/02-event-card/event-card--horizontal-image-blue.hbs
@@ -16,8 +16,10 @@
                     <a class="event-link-overlay" href="#" aria-label="Event Overlay">&nbsp;</a>
                     <h3 class="h5">{{ headline }}</h3>
                     <p>{{ subheading }}</p>
-                    <div class="right-arrow">
-                        <img src="{{ path '/college-dls/utsa/images/Corner-Arrow.png' }}" alt="Arrow Image">
+                    <div class="event-icon-container">
+                        <div class="event-icon">
+                        <i class="fas fa-arrow-right" aria-hidden="true"></i>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/components/02-components/03-card/02-event-card/event-card--horizontal-image.hbs
+++ b/components/02-components/03-card/02-event-card/event-card--horizontal-image.hbs
@@ -16,8 +16,10 @@
                     <a class="event-link-overlay" href="#" aria-label="Event Overlay">&nbsp;</a>
                     <h3 class="h5">{{ headline }}</h3>
                     <p>{{ subheading }}</p>
-                    <div class="right-arrow">
-                        <img src="{{ path '/college-dls/utsa/images/Corner-Arrow.png' }}" alt="Arrow Image">
+                    <div class="event-icon-container">
+                        <div class="event-icon">
+                        <i class="fas fa-arrow-right" aria-hidden="true"></i>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/components/02-components/03-card/02-event-card/event-card--horizontal.hbs
+++ b/components/02-components/03-card/02-event-card/event-card--horizontal.hbs
@@ -13,8 +13,10 @@
                     <a class="event-link-overlay" href="#" aria-label="Event Overlay">&nbsp;</a>
                     <h3 class="h5">{{ headline }}</h3>
                     <p>{{ subheading }}</p>
-                    <div class="right-arrow">
-                        <img src="{{ path '/college-dls/utsa/images/Corner-Arrow.png' }}" alt="Arrow Image">
+                    <div class="event-icon-container">
+                        <div class="event-icon">
+                        <i class="fas fa-arrow-right" aria-hidden="true"></i>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/components/02-components/03-card/02-event-card/event-card.scss
+++ b/components/02-components/03-card/02-event-card/event-card.scss
@@ -119,4 +119,24 @@ a.event-link-overlay:focus {
 		font-size: 35px;
 	}
 }
+
+.event-icon-container {
+	display: flex;
+	justify-content: flex-end;
+	align-items: end;
+	position: absolute;
+	width: 0px;
+	height: 0px;
+	font-size: 1.125rem;
+	top:0;
+	right:0;
+	color:white;
+	border-top: 65px solid #d3430d;
+  	border-left: 70px solid transparent;
+}
+
+.event-icon {
+	padding: 10px 12px 30px 10px;
+}
+
 /* END event-card.scss */


### PR DESCRIPTION
Removed the image that was being used to add the arrow on the event card with CSS/FA code. Updated all event card variants. Tested and working on Chrome.