### PR TITLE
Updated Profile Card CSS. Linked/Not Linked.

### DIFF
--- a/components/02-components/04-profile/01-profile-card/profile-card.scss
+++ b/components/02-components/04-profile/01-profile-card/profile-card.scss
@@ -41,11 +41,14 @@
 			font-size: 1.3rem;
 			font-weight: 700;
 			text-decoration: none;
+			color: $orange-a11y;
 		}
 
 		.profile-card-name {
 			font-size: 1.3rem;
 			font-weight: 700;
+			color: $blue;
+
 		}
 
 		.h5 {
@@ -72,6 +75,10 @@
 	}
 
 	&.blue-bg {
+		.profile-card-name {
+			color: $grey-b;
+		}
+
 		.profile-card-link {
 			color: $white;
 		}


### PR DESCRIPTION
Made profile card 'Name' blue by default. If linked, 'Name' should be orange and behave as usual (link hover, etc.). Meant to differentiate between profiles that are linked to a profile page and profiles that aren't.

Also updated the blue background version to use a grey instead of white. Might have to look at other options if it's too hard to differentiate between the grey and the white, but also I don't think we use the blue bg much.

CDLS cards are built to all be linked in the handlebars file. When I remove the link in chrome inspector the name is a plain blue, so I think it works.