### PR TITLE
788-dm-uls-not-displaying-correctly-on-action-cards

### DIFF
--- a/components/02-components/03-card/01-action-card/action-card--grey.hbs
+++ b/components/02-components/03-card/01-action-card/action-card--grey.hbs
@@ -7,6 +7,10 @@
         <div class="content-card-content position-relative grey-bg px-lg-2">
             <a href="#" class="content-card-link px-lg-2">{{heading}} </a>
             <p class="font-14 blue regular px-lg-2">{{text}}</p>
+            <ul>
+                <li>Item 1</li>
+                <li>Item 2</li>
+            </ul>
         </div>
     </div>
 </div>

--- a/components/02-components/03-card/01-action-card/action-card.hbs
+++ b/components/02-components/03-card/01-action-card/action-card.hbs
@@ -7,6 +7,10 @@
         <div class="content-card-content position-relative px-lg-2">
             <a href="#" class="content-card-link px-lg-2">{{heading}} </a>
             <p class="font-14 blue regular px-lg-2">{{text}}</p>
+            <ul>
+                <li>List item 1</li>
+                <li>List item 2</li>
+            </ul>
             {{render '@angled-button--blue'}}
         </div>
     </div>

--- a/components/02-components/03-card/01-action-card/action-card.scss
+++ b/components/02-components/03-card/01-action-card/action-card.scss
@@ -32,7 +32,7 @@
 			position: relative;
 			border-top: 6px solid $orange;
 			
-			p {
+			p, ul li {
 				font-size: 14px;
 				color: $blue;
 			}
@@ -60,7 +60,6 @@
 
 		}
 
-
 		.action-btn {
 			//position: absolute;
 			//bottom: 25px;
@@ -79,6 +78,16 @@
 		}		
 	}
 }
+
+/* Dark Mode - Component Styles - Action Card */
+@include color-mode(dark) {
+	.content-card-wrapper .content-card.white-bg .content-card-content {
+		ul li {
+			color:$blue;
+		}
+	}
+}
+/* Component Styles - Action Card END */
 
 @media (min-width: 1200px) {
 	.content-card-wrapper {
@@ -104,6 +113,7 @@
 	
 	}
 }
+
 @media (max-width: 767px) {
 	.contact-card-wrapper {
 		.content-card-img>img {


### PR DESCRIPTION
Updated Action Card CSS for dark mode. The action cards always seem to have a white bg, so I think simply adding CSS for ul li as I have done in the action card CSS is enough, but just in case I also added CSS for dark mode.