### PR TITLE
769-dm-events-details-page-is-unstyled-for-dark-mode

### DIFF
--- a/components/01-visual-styling/01-typography/01-headline/headline.scss
+++ b/components/01-visual-styling/01-typography/01-headline/headline.scss
@@ -134,6 +134,7 @@ h6 {
 	font-weight: 400;
 	letter-spacing: 1px;
 }
+
 @include color-mode(dark) {
 	h1, h2, h3, h4, h5, h6 {
 		color: $white;
@@ -143,7 +144,23 @@ h6 {
 			color: $blue;
 		}
 	}
+	.h2 {
+		font-size: 2.5rem;
+	}
+	.h3 {
+		font-size: 2.25rem;
+	}
+	.h4 {
+		font-size: 2rem;
+	}
+	.h5 {
+		font-size: 1.75rem;
+	}
+	.h6 {
+		font-size: 1.5rem;
+	}
 }
+
 @include media-breakpoint-down(lg) {
 	.headings-typography-ul>li {
 		padding-left: 0px;

--- a/components/04-reference-pages/09-events-page/events-page.scss
+++ b/components/04-reference-pages/09-events-page/events-page.scss
@@ -101,13 +101,25 @@
 /* Dark Mode - Event Page */
 @include color-mode(dark) {
 	.event-description-sec .event-description-content {
-		h2, h4, h5 {
-			color: $orange;
-		}
-		.event-des-list, h3, h6 {
+		h2, .h2, h3, .h3 {
 			color: $white;
 		}
+		h4, .h4, h5, .h5 {
+			color: $orange;
+		}
+		.event-des-list {
+			color: $white;
+			h3, .h3, h4, .h4, h5, .h5 {
+				color: $orange;
+			}
+			.left-icon {
+				color: $white;
+			}
+		}
 		.event-des-list .event-info {
+			h6, .h6 {
+				color: $white;
+			}
 			a {
 				color:$white;
 				&:hover {
@@ -117,8 +129,11 @@
 		}
 	}
 	.event-des-left {
-		h4, h5 {
+		h3, .h3, h4, .h4, h5, .h5 {
 			color: $orange;
+		}
+		h6, .h6 {
+			color: $white;
 		}
 	}
 }


### PR DESCRIPTION
Updated dark mode CSS for events page. Had to add some redundancies for H tags because I think they get overwritten in dark mode somehow. Also specified h class sizes in the typography page because that was also being lost somewhere.

I *think* this should solve all the white/orange text issues.