### PR TITLE
852-dm-blockquote-with-orange-background-has-a-contrast-error

### DIFF
--- a/components/03-sections/06-blockquote/blockquote.scss
+++ b/components/03-sections/06-blockquote/blockquote.scss
@@ -110,8 +110,11 @@
 	.blockquote-heading h3 {
 		color: $orange;
 	}
-	.blockquote-wrapper .blockquote, .blockquote-wrapper .blockquote-footer {
+	.blockquote-wrapper .blockquote {
 		color:$grey;
+	}
+	.blockquote-wrapper .blockquote-footer {
+		color: $white;
 	}
 	.blockquote-wrapper {
 		&.grey-bg {
@@ -132,7 +135,7 @@
 				color: $orange;
 			} 
 			.blockquote-footer {
-				color: $grey;
+				color: $white;
 			}
 			.blockquote-heading {
 				h2, h3 {
@@ -145,7 +148,7 @@
 				color: $blue;
 			} 
 			.blockquote-footer {
-				color: $grey;
+				color: $white;
 			}
 			.blockquote-heading {
 				h2, h3 {


### PR DESCRIPTION
Updated blockquote DM CSS to change blockquote footer, name/title, from grey to white to improve color contrast for accessibility.