### PR TITLE
Added coverage for items outside of the duotone items

### DIFF
--- a/components/03-sections/10-icon-callout/icon-callout--white.hbs
+++ b/components/03-sections/10-icon-callout/icon-callout--white.hbs
@@ -24,7 +24,7 @@
                 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
             </div>
             <div class="col-sm-12 col-md-4 col-lg-4 my-3 mb-3">
-                <span class="fa-duotone fa-basketball-hoop fa-6x p-3"></span>
+                <span class="fa-solid fa-basketball fa-6x p-3"></span>
                 <h3 class="h6">Basketball courts</h3>
                 <p>Ducimus sint saepe impedit sequi veniam quia, eveniet obcaecati doloribus consectetur laborum illum reiciendis.</p>
             </div>

--- a/components/03-sections/10-icon-callout/icon-callout.scss
+++ b/components/03-sections/10-icon-callout/icon-callout.scss
@@ -7,7 +7,7 @@
 /* Dark Mode - Icon Callout Styles */
 @include color-mode(dark) {
 	.content-callout-wrapper.white {
-        .fa-duotone {
+        .fa-6x {
             &::after {
                 color: $white;
             }


### PR DESCRIPTION
Changed the coverage from duotone to `.fa-6x` to cover items outside the duotone items since users could add any font awesome icon. 