### PR TITLE
Removed top value, so carousel doesn't overlay nav

### DIFF
--- a/components/03-sections/03-banner/banner.scss
+++ b/components/03-sections/03-banner/banner.scss
@@ -272,7 +272,7 @@
 
 	.overlay {
 		position: absolute;
-		top: 0;
+		// top: 0;
 		left: 0;
 		height: 100%;
 		width: 100%;


### PR DESCRIPTION
The overlay is causing issues with the mobile nav. I removed the top value, but let me know if there is a better way to do this. 