### PR TITLE
duotone-icons no longer in upstream

### DIFF
--- a/src/scss/_font.scss
+++ b/src/scss/_font.scss
@@ -10,7 +10,7 @@ $fa-font-path           : "../font/FontAwesome";
 @import "../../node_modules/@fortawesome/fontawesome-pro/scss/solid.scss";
 @import "../../node_modules/@fortawesome/fontawesome-pro/scss/brands.scss";
 @import "../../node_modules/@fortawesome/fontawesome-pro/scss/duotone.scss";
-@import "../../node_modules/@fortawesome/fontawesome-pro/scss/_duotone-icons.scss";
+// @import "../../node_modules/@fortawesome/fontawesome-pro/scss/_duotone-icons.scss";
 @import "../../node_modules/@fortawesome/fontawesome-pro/scss/regular.scss";
 @import "../../node_modules/@fortawesome/fontawesome-pro/scss/sharp-regular.scss";
 @import "../../node_modules/@fortawesome/fontawesome-pro/scss/sharp-solid.scss";


### PR DESCRIPTION
quick fix to get dls back in working order, latest version of FA-pro no longer has a separate file for duotone-icons