### PR TITLE
Added coverage for emergency banner in dark mode

### DIFF
--- a/components/03-sections/02-navigation/01-site-navigation/site-navigation.scss
+++ b/components/03-sections/02-navigation/01-site-navigation/site-navigation.scss
@@ -172,6 +172,10 @@
 }
 
 @include color-mode(dark) {
+	.campus-wide.alert-danger {
+		color: $white;
+	}
+
 	#header .top-navigation {
 		background-color: $grey-e;
 	}


### PR DESCRIPTION
I'm unsure if we should add the emergency banner to the DLS, but this should work for now. 