### PR TITLE
929-DLS blockquote image variant with blue bg and white h3

### DIFF
--- a/components/03-sections/06-blockquote/blockquote--blue-image-heading.hbs
+++ b/components/03-sections/06-blockquote/blockquote--blue-image-heading.hbs
@@ -1,0 +1,29 @@
+<section class="blockquote-wrapper blue-bg pt-5 pb-5">
+    <div class="container">
+        <div class="blockquote-heading">
+            <h3>A True Learning Community</h3>
+        </div>
+        <div class="image-content-wrapper">
+            <div class="row align-items-center">
+                <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">
+                    <div class="image_wrapper">
+                        <img class="clip-mask-top-right"
+                            src="{{path '/college-dls/college/images/true-learning-community.png' }}"
+                            alt="Community Image">
+                    </div>
+                </div>
+                <div class="col-xxl-8 col-xl-8 col-lg-8 col-md-8 col-sm-12">
+                    <div class="image-right-content">
+                        <figure>
+                            <blockquote class="blockquote">“Lorem ipsum dolor sit amet,
+                                consectetur
+                                adipiscing elit. Maecenas tincidunt urna a porta lobortis. Aliquam sit amet eros quam.”
+                            </blockquote>
+                            <footer class="blockquote-footer"><strong>Jane Doe,</strong> Alumni, Alvarez School of Business 2019</footer>
+                        </figure>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/components/03-sections/06-blockquote/blockquote.scss
+++ b/components/03-sections/06-blockquote/blockquote.scss
@@ -24,7 +24,7 @@
 	&.blue-bg {
 		color: $orange;
 		.blockquote-heading h3 {
-			color: $white !important;
+			color: $white;
 		}
 
 		.blockquote-footer {

--- a/components/03-sections/06-blockquote/blockquote.scss
+++ b/components/03-sections/06-blockquote/blockquote.scss
@@ -23,8 +23,8 @@
 
 	&.blue-bg {
 		color: $orange;
-		.blockquote-heading {
-			color: $white;
+		.blockquote-heading h3 {
+			color: $white !important;
 		}
 
 		.blockquote-footer {


### PR DESCRIPTION
Added variant for Blockquote Image with a blue background and white h3. For some reason it wouldn't pick it up until I added h-tag `.blockquote-heading h3` specificity to the css selector.