### PR TITLE
Issue 953 - Smaller header title size for mobile screens

### DIFF
--- a/components/03-sections/03-banner/banner.scss
+++ b/components/03-sections/03-banner/banner.scss
@@ -138,6 +138,16 @@
 		text-align: center;
 		max-width: 100%;
 	}
+
+	.banner {
+		.single-title-heading,
+		.page-video-title {
+			font-size: 2.5rem;
+			line-height: 3rem;
+			color: #fff;
+			font-weight: 400;
+		}
+	}
 }
 
 /* END Alternative Department Banner */


### PR DESCRIPTION
Added CSS rule to decrease header title font size so longer titles fit better on mobile screens. Hopefully this keeps 99.9% of words from getting cut off.