### PR TITLE
1023 dls gallery image title is showing html in text form

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "fullcalendar": "^3.10.0",
     "gulp-uglify": "^3.0.2",
     "jquery": "^3.6.4",
-    "magnific-popup": "^1.1.0",
+    "magnific-popup": "^1.2.0",
     "minimist": "^1.2.7",
     "moment": "^2.30.1",
     "tom-select": "^2.4.3"

--- a/src/js/bundle/college-dls-umd.js
+++ b/src/js/bundle/college-dls-umd.js
@@ -279,6 +279,7 @@ $(document).ready(function () {
     if ($(".popup-gallery").length > 0) {
         $(".popup-gallery").magnificPopup({
             type: "image",
+            allowHTMLInTemplate: true,
             gallery: {
                 enabled: true,
                 arrowMarkup: '<button title="%title%" type="button" class="mfp-arrow mfp-arrow-%dir%"></button>', // markup of an arrow button


### PR DESCRIPTION
- Updated magnific-popup version to 1.2.0
- Added a new option to allow HTML 