### PR TITLE
Branding styles, Dark Mode and accessibility fixes

### DIFF
--- a/components/01-visual-styling/05-branding-standards/01-global-header/global-header.scss
+++ b/components/01-visual-styling/05-branding-standards/01-global-header/global-header.scss
@@ -291,7 +291,7 @@ $bold: 700;
 		li {
 			margin: 0;
 			display: inline-block;
-			border-left: 1px solid $blue-light;
+			border-left: 1px solid $blue-highlight;
 			padding-left: 1rem;
 			line-height: 1;
 

--- a/components/02-components/04-profile/03-profile-info/profile-info.hbs
+++ b/components/02-components/04-profile/03-profile-info/profile-info.hbs
@@ -2,6 +2,8 @@
     <div class="col-xxl-12 col-xl-12 col-lg-12 col-md-12 col-sm-12">
         <h2>{{ name }}</h2>
         <p class="profile-details-title">{{ title }}, {{ department }}</p>
+        <p class="profile-details-title">Additional Job Title</p>
+        <p class="profile-details-title">Additional Job Title</p>
     </div>
     <div class="row no-mrg pt-4">
         <div class="col-xxl-4 col-xl-4 col-lg-4 col-md-4 col-sm-12">

--- a/components/02-components/04-profile/03-profile-info/profile-info.scss
+++ b/components/02-components/04-profile/03-profile-info/profile-info.scss
@@ -25,16 +25,14 @@
 
     h2 {
         color: $blue;
-        font-weight: 700;
-        font-size: 2.25rem;
-        margin-bottom: 5px;
+        font-size: 2rem;
+        margin-bottom: .25rem;
     }
 
     h3 {
         color: $orange-a11y;
-        font-weight: 700;
-        font-size: 2rem;
-        margin-bottom: 5px;
+        font-size: 1.75rem;
+        margin-bottom: .25rem;
     }
 
     .profile-details- {
@@ -45,12 +43,12 @@
 
             p {
                 font-size: 1rem;
-                margin-bottom: 30px;
+                margin-bottom: 1.5rem;
             }
 
             .icon {
                 display: inline-block;
-                font-size: 22px;
+                font-size: 1.25rem;
                 text-align: center;
                 width: 25px;
                 margin-right: 5px;
@@ -59,13 +57,14 @@
 
         &title {
             color: $orange-a11y;
-            font-size: 1.5rem;
+            font-size: 1.25rem;
             font-weight: 600;
+            margin-bottom: .125rem;
         }
 
         &list > ul {
-            margin-bottom: 30px;
-            font-size: 1.125rem;
+            margin-bottom: 1.5rem;
+            font-size: 1rem;
             font-weight: 600;
         }
 
@@ -87,7 +86,7 @@
         */
         &>li {
             //width: 50%;
-            margin-bottom: 7px;
+            margin-bottom: .25rem;
         }
     }
     
@@ -105,7 +104,7 @@
 @media (max-width: 991px) {
 
 	.profile-card-list .row>div {
-		margin-bottom: 20px;
+		margin-bottom: 1.25rem;
 	}
 }
 

--- a/components/03-sections/02-navigation/01-site-navigation/site-navigation.scss
+++ b/components/03-sections/02-navigation/01-site-navigation/site-navigation.scss
@@ -199,13 +199,13 @@
 		.navbar-nav > .nav-item .dropdown-menu {
 			background-color: $grey;
 		}
-		img.college-logo {
-			filter: grayscale(1) brightness(10) contrast(1);
-			&:hover {
-				filter: grayscale(0) brightness(100%) contrast(100%);
+		a.navbar-brand {
+				filter: grayscale(1) brightness(10) contrast(1);
+				&:hover, &:focus, &:active {
+					filter: grayscale(0) brightness(100%) contrast(100%);
+				}
 			}
 		}
-	}
 }
  
 .admissions {

--- a/components/03-sections/02-navigation/02-breadcrumb/breadcrumb.hbs
+++ b/components/03-sections/02-navigation/02-breadcrumb/breadcrumb.hbs
@@ -3,9 +3,9 @@
     <div class="container">
         <ul class="list-unstyled">
             <li class="crumb-item">
-                <a class="link-text" href="index.html">Home</a>
+                <a href="index.html">Home</a>
                 <span class="breadcrumb-divider">&#160;/&#160;</span>
-                <span class="unlink-text">{{ breadcrumb.title }}</span></li>
+                <span>{{ breadcrumb.title }}</span></li>
         </ul>
     </div>
 </div>

--- a/components/03-sections/02-navigation/02-breadcrumb/breadcrumb.scss
+++ b/components/03-sections/02-navigation/02-breadcrumb/breadcrumb.scss
@@ -8,32 +8,21 @@
 	background-color: $blue-b;
 	padding: 12px 0px;
 
-	.crumb-item .link-text:hover {
-		color: $orange-a11y;
-		-webkit-transition: all 0.3s ease-in-out;
-		-o-transition: all 0.3s ease-in-out;
-		transition: all 0.3s ease-in-out;
-	}
-
 	.crumb-item {
 		color: $white;
 		font-size: .875rem;
-		font-weight: 600;
-	}
-
-	.crumb-item .link-text {
-		color: $white;
 		font-weight: 300;
-	}
 
-	.crumb-item .unlink-text a {
-		color: $white;
-		&:hover {
-			color: $orange-a11y;
-			background-color: $grey;
-			-webkit-transition: all 0.3s ease-in-out;
-			-o-transition: all 0.3s ease-in-out;
-			transition: all 0.3s ease-in-out;
+		&>a {
+			color: $white;
+			font-weight: 600;
+			&:hover, &:focus, &:active {
+				color: $orange-a11y;
+				background-color: $grey;
+				-webkit-transition: all 0.3s ease-in-out;
+				-o-transition: all 0.3s ease-in-out;
+				transition: all 0.3s ease-in-out;
+			}
 		}
 	}
 


### PR DESCRIPTION
Additional style updates and fixes for both regular and dark mode. 

Breadcrumb styles updated so it's not white on grey in DM. 

Top header separators updated to match the blue used in the UTSA header. 

Added focus and active styles to main logo in nav and breadcrumbs for accessibility.

I had to make some updates to the html on the breadcrumbs and got rid of some classes that weren't needed, so it might have to be updated on Cascade as well to match it.