### PR TITLE
feat(.devcontainer): Update devcontainer name for agent sandbox

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
-	"name": "Node.js",
+	"name": "Agent Sandbox - javascript-node:dev-24-bookworm",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"build": {
 		"dockerfile": "Dockerfile",


### PR DESCRIPTION
Updated the devcontainer name to "Agent Sandbox - javascript-node:dev-24-bookworm"
to better reflect the environment's purpose for agent development.