### PR TITLE
ci: Fix Azure SWA deploy app_location for skip_app_build

### DIFF
--- a/.github/workflows/azure-static-web-apps-proud-cliff-061107310.yml
+++ b/.github/workflows/azure-static-web-apps-proud-cliff-061107310.yml
@@ -55,9 +55,7 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_CLIFF_061107310 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          app_location: "" # App source code path
-          api_location: "" # Api source code path - optional
-          output_location: "dist" # Built app content directory - optional
+          app_location: "dist"
           skip_app_build: true
 
   close_pull_request_job:


### PR DESCRIPTION
Sets `app_location` to `dist` in the Azure SWA workflow. With `skip_app_build: true`, the action ignores `output_location` and serves directly from `app_location`, so it needs to point to the pre-built output directory.

Follow-up to #1085.