### PR TITLE
Contact Callout CSS/Layout Fix

### DIFF
--- a/components/02-components/04-profile/02-contact-callout/contact-callout.hbs
+++ b/components/02-components/04-profile/02-contact-callout/contact-callout.hbs
@@ -1,11 +1,11 @@
 <div class="contact-card">
     <div class="row align-items-center mb-5 mt-4">
-        <div class="col-12 col-sm-6 col-xl-4">
+        <div class="col-xs-6 col-sm-4 col-md-4 col-lg-4 col-xl-4">
             <div class="staff-card-img">
                 <img class="clip-mask-top-right" src="{{path image}}" alt="Card Image" />
             </div>
         </div>
-        <div class="col-12 col-sm-6 col-xl-8">
+        <div class="col-xs-12 col-sm-8 col-md-8 col-lg-8 col-xl-8">
             <div class="staff-card-content">
                 <h2 class="h4">Contact</h2>
                 <p class="staff-card-name">

--- a/components/04-reference-pages/02-department-home-page/department-home-page.scss
+++ b/components/04-reference-pages/02-department-home-page/department-home-page.scss
@@ -25,10 +25,6 @@ ul.departmental-ul-list>li {
 	padding-bottom: 56px;
 }
 
-.page-text-wrapper .contact-card {
-	max-width: 350px;
-}
-
 @include media-breakpoint-down(lg) {
 	.department-information {
 		padding-top: 10px;


### PR DESCRIPTION
Updated Contact Callout card's boostrap columns and removed an unnecessary max-width CSS so the image resizes better across all screen sizes.