### PR TITLE
Issue 1115 Default Bootstrap tables dark mode fixes

### DIFF
--- a/components/01-visual-styling/01-typography/05-table/table.scss
+++ b/components/01-visual-styling/01-typography/05-table/table.scss
@@ -1,20 +1,20 @@
 /* components/01-visual-styling/02-typography/06-table/table.scss */
 /* BEGIN table.scss */
 .medium-headline-component h2 {
-    font-size: 32px;
+    font-size: 2rem;
     color: $blue;
     font-weight: 700;
     margin-bottom: 30px;
 }
 
-table {
+table, .table {
 	width: 100%;
 	padding: 0px 15px;
 	margin-bottom: 20px;
 
 	thead th, th {
 		font-weight: bold;
-		font-size: 17px;
+		font-size: .9rem;
 		color: $orange-a11y;
 	}
 	
@@ -30,7 +30,7 @@ table {
 	
 	tr td {
 		padding: 12px 25px;
-		font-size: 17px;
+		font-size: .9rem;
 		color: $blue;
 	}
 	caption {
@@ -113,6 +113,19 @@ table {
 
 	table>caption {
 		color: $grey;
+	}
+
+	.table {
+		p, ul>li, ol>li {
+			color: $blue;
+		}
+		a {
+			color: $blue;
+			&:hover {
+				color: $white;
+				background-color: $blue;
+			}
+		}
 	}
 
 	table.table tr td, table.table tr th {

--- a/components/04-reference-pages/20-bootstrap-testing/bootstrap-component-testing.hbs
+++ b/components/04-reference-pages/20-bootstrap-testing/bootstrap-component-testing.hbs
@@ -46,25 +46,30 @@
       </thead>
       <tbody>
         <tr>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
+          <td><p>content in p tags.</p></td>
+          <td><p>content in p tags.</p></td>
+          <td><p>content in p tags.</p></td>
+          <td><p>content in p tags.</p></td>
+          <td><p>content in p tags.</p></td>
         </tr>
         <tr>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
+          <td><ul><li>content in ul list tags.</li>
+              <li>content in ul list tags.</li></ul></td>
+          <td><ul><li>content in ul list tags.</li>
+              <li>content in ul list tags.</li></ul></td>
+          <td><ol><li>content in ol list tags.</li>
+              <li>content in ol list tags.</li></ol></td>
+          <td><ol><li>content in ol list tags.</li>
+              <li>content in ol list tags.</li></ol></td>
+          <td><ol><li>content in ol list tags.</li>
+              <li>content in ol list tags.</li></ol></td>
         </tr>
         <tr>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
+          <td><a href=#>Linked content.</a></td>
+          <td><a href=#>Linked content.</a></td>
+          <td><a href=#>Linked content.</a></td>
+          <td><a href=#>Linked content.</a></td>
+          <td><a href=#>Linked content.</a></td>
         </tr>
         <tr>
           <td>content</td>
@@ -96,25 +101,30 @@
       </thead>
       <tbody>
         <tr>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
+          <td><p>content in p tags.</p></td>
+          <td><p>content in p tags.</p></td>
+          <td><p>content in p tags.</p></td>
+          <td><p>content in p tags.</p></td>
+          <td><p>content in p tags.</p></td>
         </tr>
         <tr>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
+          <td><ul><li>content in ul list tags.</li>
+              <li>content in ul list tags.</li></ul></td>
+          <td><ul><li>content in ul list tags.</li>
+              <li>content in ul list tags.</li></ul></td>
+          <td><ol><li>content in ol list tags.</li>
+              <li>content in ol list tags.</li></ol></td>
+          <td><ol><li>content in ol list tags.</li>
+              <li>content in ol list tags.</li></ol></td>
+          <td><ol><li>content in ol list tags.</li>
+              <li>content in ol list tags.</li></ol></td>
         </tr>
         <tr>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
+          <td><a href=#>Linked content.</a></td>
+          <td><a href=#>Linked content.</a></td>
+          <td><a href=#>Linked content.</a></td>
+          <td><a href=#>Linked content.</a></td>
+          <td><a href=#>Linked content.</a></td>
         </tr>
         <tr>
           <td>content</td>
@@ -146,25 +156,30 @@
       </thead>
       <tbody>
         <tr>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
+          <td><p>content in p tags.</p></td>
+          <td><p>content in p tags.</p></td>
+          <td><p>content in p tags.</p></td>
+          <td><p>content in p tags.</p></td>
+          <td><p>content in p tags.</p></td>
         </tr>
         <tr>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
+          <td><ul><li>content in ul list tags.</li>
+              <li>content in ul list tags.</li></ul></td>
+          <td><ul><li>content in ul list tags.</li>
+              <li>content in ul list tags.</li></ul></td>
+          <td><ol><li>content in ol list tags.</li>
+              <li>content in ol list tags.</li></ol></td>
+          <td><ol><li>content in ol list tags.</li>
+              <li>content in ol list tags.</li></ol></td>
+          <td><ol><li>content in ol list tags.</li>
+              <li>content in ol list tags.</li></ol></td>
         </tr>
         <tr>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
-          <td>content</td>
+          <td><a href=#>Linked content.</a></td>
+          <td><a href=#>Linked content.</a></td>
+          <td><a href=#>Linked content.</a></td>
+          <td><a href=#>Linked content.</a></td>
+          <td><a href=#>Linked content.</a></td>
         </tr>
         <tr>
           <td>content</td>


### PR DESCRIPTION
Added dark mode fixes for default bootstrap table classes so text in paragraph, list tags and links would display correctly and adjusted some font sizes to rem sizes for consistency.

Also added text in p tags, list tags and links to the bootstrap component testing page to test those fixes.