### PR TITLE
Fix for mobile menu background

### DIFF
--- a/components/03-sections/02-navigation/01-site-navigation/site-navigation.scss
+++ b/components/03-sections/02-navigation/01-site-navigation/site-navigation.scss
@@ -576,7 +576,7 @@
 	#header .navbar-nav>.nav-item .dropdown-menu {
 		position: initial;
 		width: 100%;
-		background-color: transparent;
+		background-color: $white;
 		padding-top: 0px;
 		padding-bottom: 20px;
 	}


### PR DESCRIPTION
Updated mobile nav background color to white from trasparent. Eliminates issue in light mode where nav links have transparent background and thus conflict with the rest of the nav items.