### PR TITLE
Fix RFI form select not clearing on type (#943)

### DIFF
--- a/components/02-components/01-form/form.scss
+++ b/components/02-components/01-form/form.scss
@@ -187,6 +187,10 @@
 		font-size: .875rem;
 }
 
+.ts-wrapper.single.focus.has-items .ts-control > .item {
+	display: none;
+}
+
 .textarea-design textarea::-webkit-input-placeholder {
 	color: $blue;
 }


### PR DESCRIPTION
## Summary
- Hide the rendered TomSelect selection chip when a single-select is focused and already has a value, so typing into the control replaces the visible text instead of overlapping it.
- CSS-only fix in `components/02-components/01-form/form.scss` — no JS changes.

Closes #943.

## Test plan
- [ ] Open the RFI form (`form--rfi`) in Fractal.
- [ ] Pick a value in any select (e.g. Term of Entry, Program/Major, Admit Type).
- [ ] Re-open the dropdown and start typing — confirm the previously selected text is no longer visible behind the search input.
- [ ] Blur without changing the selection and confirm the original value is still selected.
- [ ] Verify other select-driven forms (search/filter pages) still render selected values correctly when not focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)