### PR TITLE
Updated documentation for Content Card and Content List components

### DIFF
--- a/components/02-components/03-card/03-content-card/content-card.readme.md
+++ b/components/02-components/03-card/03-content-card/content-card.readme.md
@@ -4,7 +4,7 @@ Original source from [https://utsa-asc.github.io/college-dls/college-dls/referen
 
 ## Implementation Notes
 
-This is a smaller level component and is not designed to be used stand alone.  TODO: Create a separate preview template for this component to pop into a col-3 or col-4 width size.
+This is a smaller level component and is not designed to be used stand alone.
 
 To use a component of this type, please see the corresponding [Content List](content-list) components.
 

--- a/components/03-sections/05-content-group/01-content-list/content-list.readme.md
+++ b/components/03-sections/05-content-group/01-content-list/content-list.readme.md
@@ -1,11 +1,12 @@
 # Content List Documentation
 
 Original source from [https://utsa-asc.github.io/college-dls/college-dls/reference/card-tiles.html#content-card](https://utsa-asc.github.io/college-dls/college-dls/reference/card-tiles.html#content-card)
+
 ## Implementation Notes
 
-All Content Group level components are designed to be full width.  Depending on the size of the content and iamges, you may utilized 3 or 4 internal card components within a row.  
+All Content Group level components are designed to be full width. Depending on the size of the content and images, you may utilize 3 or 4 internal card components within a row.
 
 ## Media Requirements
-- Action Card Image: Our standard image size is 460px (width) by 210px (height), 72 ppi (pixels per inch) jpeg or png.
+- Content Card Image: Our standard image size is 460px (width) by 210px (height), 72 ppi (pixels per inch) jpeg or png.
 
     - Image should be no larger and 300kb (kilobytes)


### PR DESCRIPTION
- Removed TODO note from Content Card readme. I think we have this covered already. 
- Corrected image reference in Content List readme.

Let me know if anything else is incorrect. I wasn't sure if the image recommendations were correct. This is more for the programs block, so I wasn't sure if we should rename. Also, I don't think we use any of the variants in production. 